### PR TITLE
Setup NextAuth with Prisma and protected routes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+DATABASE_URL="file:./dev.db"
+NEXTAUTH_SECRET="change-me"
+GOOGLE_CLIENT_ID="your-google-client-id"
+GOOGLE_CLIENT_SECRET="your-google-client-secret"
+GITHUB_ID="your-github-client-id"
+GITHUB_SECRET="your-github-client-secret"

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next", "next/core-web-vitals"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+node_modules
+.env
+.next
+.prisma
+
+# Debug logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -1,0 +1,24 @@
+import { redirect } from "next/navigation";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import DeleteAccountButton from "@/app/components/delete-account-button";
+
+export default async function AccountPage() {
+  const session = await getServerSession(authOptions);
+
+  if (!session) {
+    redirect("/login");
+  }
+
+  return (
+    <div className="container">
+      <h1>Mon compte</h1>
+      <p>Gérez les informations de votre profil.</p>
+      <div className="actions">
+        <span>Nom : {session.user?.name ?? "Non renseigné"}</span>
+        <span>Email : {session.user?.email ?? "Non renseigné"}</span>
+        <DeleteAccountButton />
+      </div>
+    </div>
+  );
+}

--- a/app/api/account/delete/route.ts
+++ b/app/api/account/delete/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+
+export async function DELETE() {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.user?.id) {
+    return new NextResponse("Non autorisé", { status: 401 });
+  }
+
+  await prisma.user.delete({
+    where: { id: session.user.id }
+  });
+
+  return NextResponse.json({ success: true });
+}

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,6 @@
+import NextAuth from "next-auth";
+import { authOptions } from "@/lib/auth";
+
+const handler = NextAuth(authOptions);
+
+export { handler as GET, handler as POST };

--- a/app/components/auth-status.tsx
+++ b/app/components/auth-status.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import Link from "next/link";
+import { signOut, useSession } from "next-auth/react";
+import { useTransition } from "react";
+
+export default function AuthStatus() {
+  const { status, data } = useSession();
+  const [isPending, startTransition] = useTransition();
+
+  if (status === "loading") {
+    return <span>Chargement...</span>;
+  }
+
+  if (status === "authenticated" && data?.user) {
+    return (
+      <div className="actions" style={{ flexDirection: "row", gap: "0.5rem" }}>
+        <span>Bonjour&nbsp;{data.user.name ?? data.user.email ?? "Utilisateur"}</span>
+        <button
+          type="button"
+          onClick={() =>
+            startTransition(() => {
+              void signOut({ callbackUrl: "/login" });
+            })
+          }
+          disabled={isPending}
+        >
+          Se déconnecter
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="actions" style={{ flexDirection: "row", gap: "0.5rem" }}>
+      <Link href="/login">Connexion</Link>
+    </div>
+  );
+}

--- a/app/components/delete-account-button.tsx
+++ b/app/components/delete-account-button.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useTransition } from "react";
+import { signOut } from "next-auth/react";
+
+export default function DeleteAccountButton() {
+  const [isPending, startTransition] = useTransition();
+
+  const handleDelete = async () => {
+    startTransition(async () => {
+      const response = await fetch("/api/account/delete", {
+        method: "DELETE"
+      });
+
+      if (response.ok) {
+        await signOut({ callbackUrl: "/login" });
+      } else {
+        console.error("Suppression impossible", await response.text());
+      }
+    });
+  };
+
+  return (
+    <button type="button" onClick={handleDelete} disabled={isPending}>
+      Supprimer mon compte
+    </button>
+  );
+}

--- a/app/components/session-provider.tsx
+++ b/app/components/session-provider.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { SessionProvider } from "next-auth/react";
+import { type Session } from "next-auth";
+import { type ReactNode } from "react";
+
+interface Props {
+  children: ReactNode;
+  session: Session | null;
+}
+
+export default function NextAuthSessionProvider({ children, session }: Props) {
+  return <SessionProvider session={session}>{children}</SessionProvider>;
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,24 @@
+import { redirect } from "next/navigation";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+
+export default async function DashboardPage() {
+  const session = await getServerSession(authOptions);
+
+  if (!session) {
+    redirect("/login");
+  }
+
+  return (
+    <div className="container">
+      <h1>Tableau de bord</h1>
+      <p>
+        Bienvenue {session.user?.name ?? session.user?.email}! Ceci est une page protégée accessible
+        uniquement aux utilisateurs authentifiés.
+      </p>
+      <div className="actions">
+        <span>Votre identifiant utilisateur : {session.user?.id}</span>
+      </div>
+    </div>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,103 @@
+:root {
+  color-scheme: light dark;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: #0f172a;
+  color: #f8fafc;
+  display: flex;
+  flex-direction: column;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+main {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+}
+
+button {
+  cursor: pointer;
+}
+
+.container {
+  width: 100%;
+  max-width: 480px;
+  background: rgba(15, 23, 42, 0.75);
+  padding: 2rem;
+  border-radius: 1rem;
+  box-shadow: 0 20px 25px -15px rgba(15, 23, 42, 0.6);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.actions button,
+.actions a {
+  border: none;
+  border-radius: 9999px;
+  padding: 0.75rem 1rem;
+  font-size: 1rem;
+  font-weight: 600;
+  background: linear-gradient(135deg, #38bdf8, #6366f1);
+  color: #0f172a;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  text-align: center;
+}
+
+.actions button:hover,
+.actions a:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 20px -12px rgba(56, 189, 248, 0.8);
+}
+
+.actions button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+header {
+  padding: 1.5rem 2rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.navLinks {
+  display: flex;
+  gap: 1rem;
+}
+
+.navLinks a {
+  padding: 0.5rem 0.75rem;
+  border-radius: 9999px;
+  background: rgba(148, 163, 184, 0.2);
+}
+
+.navLinks a:hover {
+  background: rgba(148, 163, 184, 0.35);
+}
+
+.footer {
+  text-align: center;
+  padding: 1rem 0;
+  font-size: 0.875rem;
+  color: rgba(226, 232, 240, 0.65);
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,42 @@
+import "@/app/globals.css";
+import Link from "next/link";
+import { type Metadata } from "next";
+import { type ReactNode } from "react";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import SessionProvider from "@/app/components/session-provider";
+import AuthStatus from "@/app/components/auth-status";
+
+export const metadata: Metadata = {
+  title: "Projet Site Marketing",
+  description: "Application de démonstration avec NextAuth"
+};
+
+export default async function RootLayout({
+  children
+}: {
+  children: ReactNode;
+}) {
+  const session = await getServerSession(authOptions);
+
+  return (
+    <html lang="fr">
+      <body>
+        <SessionProvider session={session}>
+          <header>
+            <Link href="/">Projet</Link>
+            <nav className="navLinks">
+              <Link href="/dashboard">Dashboard</Link>
+              <Link href="/account">Mon compte</Link>
+            </nav>
+            <AuthStatus />
+          </header>
+          <main>{children}</main>
+          <footer className="footer">
+            Propulsé par Next.js, NextAuth et Prisma.
+          </footer>
+        </SessionProvider>
+      </body>
+    </html>
+  );
+}

--- a/app/login/login-buttons.tsx
+++ b/app/login/login-buttons.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { signIn } from "next-auth/react";
+import { useTransition } from "react";
+
+export default function LoginButtons() {
+  const [isPending, startTransition] = useTransition();
+
+  const handleSignIn = (provider: "google" | "github") => {
+    startTransition(() => {
+      void signIn(provider, { callbackUrl: "/dashboard" });
+    });
+  };
+
+  return (
+    <div className="actions">
+      <button type="button" onClick={() => handleSignIn("google")} disabled={isPending}>
+        Continuer avec Google
+      </button>
+      <button type="button" onClick={() => handleSignIn("github")} disabled={isPending}>
+        Continuer avec GitHub
+      </button>
+    </div>
+  );
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,20 @@
+import { redirect } from "next/navigation";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import LoginButtons from "@/app/login/login-buttons";
+
+export default async function LoginPage() {
+  const session = await getServerSession(authOptions);
+
+  if (session) {
+    redirect("/dashboard");
+  }
+
+  return (
+    <div className="container">
+      <h1>Connexion</h1>
+      <p>Sélectionnez un fournisseur pour vous connecter.</p>
+      <LoginButtons />
+    </div>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,30 @@
+import Link from "next/link";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+
+export default async function HomePage() {
+  const session = await getServerSession(authOptions);
+
+  return (
+    <div className="container">
+      <h1>Bienvenue sur le projet marketing</h1>
+      <p>
+        Cette application démontre une intégration complète de NextAuth avec Google et GitHub,
+        Prisma comme base de données et des routes protégées via middleware.
+      </p>
+      <div className="actions">
+        {session ? (
+          <>
+            <span>Vous êtes connecté en tant que {session.user?.email ?? session.user?.name}.</span>
+            <Link href="/dashboard">Accéder au tableau de bord</Link>
+          </>
+        ) : (
+          <>
+            <span>Commencez par vous authentifier.</span>
+            <Link href="/login">Se connecter</Link>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,0 +1,60 @@
+import { PrismaAdapter } from "@/lib/prisma-adapter";
+import GoogleProvider from "next-auth/providers/google";
+import GitHubProvider from "next-auth/providers/github";
+import { type NextAuthOptions } from "next-auth";
+import { prisma } from "@/lib/prisma";
+
+export const authOptions: NextAuthOptions = {
+  adapter: PrismaAdapter(prisma),
+  session: {
+    strategy: "jwt"
+  },
+  pages: {
+    signIn: "/login"
+  },
+  providers: [
+    GoogleProvider({
+      clientId: process.env.GOOGLE_CLIENT_ID ?? "",
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET ?? ""
+    }),
+    GitHubProvider({
+      clientId: process.env.GITHUB_ID ?? "",
+      clientSecret: process.env.GITHUB_SECRET ?? ""
+    })
+  ],
+  callbacks: {
+    async signIn({ profile }) {
+      if (!profile) {
+        return true;
+      }
+
+      if ("email_verified" in profile) {
+        const verified = (profile as { email_verified?: boolean }).email_verified;
+        if (verified === false) {
+          return false;
+        }
+      }
+
+      if ("verified" in profile) {
+        const verified = (profile as { verified?: boolean }).verified;
+        if (verified === false) {
+          return false;
+        }
+      }
+
+      return true;
+    },
+    async session({ session, token }) {
+      if (session.user && token.sub) {
+        session.user.id = token.sub;
+      }
+      return session;
+    },
+    async jwt({ token, user }) {
+      if (user) {
+        token.sub = user.id;
+      }
+      return token;
+    }
+  }
+};

--- a/lib/prisma-adapter.ts
+++ b/lib/prisma-adapter.ts
@@ -1,0 +1,93 @@
+import type { Adapter, AdapterAccount } from "next-auth/adapters";
+import type { PrismaClient } from "@prisma/client";
+
+export function PrismaAdapter(prisma: PrismaClient): Adapter {
+  return {
+    async createUser(data) {
+      return prisma.user.create({
+        data
+      });
+    },
+    async getUser(id) {
+      return prisma.user.findUnique({
+        where: { id }
+      });
+    },
+    async getUserByEmail(email) {
+      return prisma.user.findUnique({
+        where: { email }
+      });
+    },
+    async getUserByAccount({ provider, providerAccountId }) {
+      const account = await prisma.account.findUnique({
+        where: { provider_providerAccountId: { provider, providerAccountId } },
+        include: { user: true }
+      });
+      return account?.user ?? null;
+    },
+    async updateUser(data) {
+      if (!data.id) {
+        throw new Error("User id is required to update user");
+      }
+      return prisma.user.update({
+        where: { id: data.id },
+        data
+      });
+    },
+    async deleteUser(id) {
+      return prisma.user.delete({
+        where: { id }
+      });
+    },
+    async linkAccount(account) {
+      await prisma.account.create({
+        data: account as AdapterAccount
+      });
+      return account;
+    },
+    async unlinkAccount({ provider, providerAccountId }) {
+      return prisma.account.delete({
+        where: { provider_providerAccountId: { provider, providerAccountId } }
+      });
+    },
+    async createSession(data) {
+      return prisma.session.create({
+        data
+      });
+    },
+    async getSessionAndUser(sessionToken) {
+      const session = await prisma.session.findUnique({
+        where: { sessionToken },
+        include: { user: true }
+      });
+      if (!session) return null;
+      const { user, ...sessionData } = session;
+      return { session: sessionData, user };
+    },
+    async updateSession(data) {
+      return prisma.session.update({
+        where: { sessionToken: data.sessionToken },
+        data
+      });
+    },
+    async deleteSession(sessionToken) {
+      return prisma.session.delete({
+        where: { sessionToken }
+      });
+    },
+    async createVerificationToken(data) {
+      return prisma.verificationToken.create({
+        data
+      });
+    },
+    async useVerificationToken({ identifier, token }) {
+      try {
+        return await prisma.verificationToken.delete({
+          where: { identifier_token: { identifier, token } }
+        });
+      } catch (error) {
+        return null;
+      }
+    }
+  };
+}

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,0 +1,12 @@
+import { PrismaClient } from "@prisma/client";
+
+declare global {
+  // eslint-disable-next-line no-var
+  var prisma: PrismaClient | undefined;
+}
+
+export const prisma = globalThis.prisma ?? new PrismaClient();
+
+if (process.env.NODE_ENV !== "production") {
+  globalThis.prisma = prisma;
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,5 @@
+export { default } from "next-auth/middleware";
+
+export const config = {
+  matcher: ["/dashboard", "/account"]
+};

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "projet-site-marketing",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "@prisma/client": "5.10.2",
+    "next": "14.1.0",
+    "next-auth": "4.24.5",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "20.11.17",
+    "@types/react": "18.2.48",
+    "@types/react-dom": "18.2.18",
+    "eslint": "8.56.0",
+    "eslint-config-next": "14.1.0",
+    "prisma": "5.10.2",
+    "typescript": "5.3.3"
+  }
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,55 @@
+// Prisma schema for NextAuth.js
+// SQLite database for development simplicity
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id            String    @id @default(cuid())
+  name          String?
+  email         String?   @unique
+  emailVerified DateTime?
+  image         String?
+  accounts      Account[]
+  sessions      Session[]
+}
+
+model Account {
+  id                String  @id @default(cuid())
+  userId            String
+  type              String
+  provider          String
+  providerAccountId String
+  refresh_token     String?
+  access_token      String?
+  expires_at        Int?
+  token_type        String?
+  scope             String?
+  id_token          String?
+  session_state     String?
+  user              User    @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([provider, providerAccountId])
+}
+
+model Session {
+  id           String   @id @default(cuid())
+  sessionToken String   @unique
+  userId       String
+  expires      DateTime
+  user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+}
+
+model VerificationToken {
+  identifier String
+  token      String   @unique
+  expires    DateTime
+
+  @@unique([identifier, token])
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx", "**/*.mjs"],
+  "exclude": ["node_modules"]
+}

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -1,0 +1,9 @@
+import NextAuth, { DefaultSession } from "next-auth";
+
+declare module "next-auth" {
+  interface Session {
+    user?: DefaultSession["user"] & {
+      id?: string;
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- configure NextAuth route handler with Google and GitHub providers, Prisma adapter, JWT sessions and strict sign-in validation
- add authentication-aware layout, public landing page, login form, and secured dashboard and account screens with account deletion flow
- introduce Prisma schema, helper libraries, and middleware to guard private routes while documenting required environment variables

## Testing
- npm install *(fails: 403 Forbidden fetching scoped packages from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d53bce36d88329bb59d0daee976054