### PR TITLE
Add legal pages and cookie management

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,0 +1,342 @@
+:root {
+  --color-primary: #3f51b5;
+  --color-primary-dark: #303f9f;
+  --color-background: #f6f8fb;
+  --color-text: #1f2633;
+  --color-muted: #5f6b7d;
+  --color-border: #d5dce6;
+  --color-footer: #131a2a;
+  --color-footer-text: #f5f7fa;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  color: var(--color-text);
+  background-color: var(--color-background);
+  line-height: 1.6;
+}
+
+body.no-scroll {
+  overflow: hidden;
+}
+
+a {
+  color: var(--color-primary);
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  text-decoration: underline;
+}
+
+header {
+  background: white;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.header-inner {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 1.5rem 1.25rem;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.branding h1 {
+  margin: 0;
+  font-size: 1.6rem;
+  color: var(--color-primary-dark);
+}
+
+nav ul {
+  list-style: none;
+  display: flex;
+  gap: 1.5rem;
+  margin: 0;
+  padding: 0;
+}
+
+nav a {
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.hero {
+  max-width: 1100px;
+  margin: 3rem auto;
+  padding: 0 1.25rem;
+  text-align: center;
+}
+
+.hero h2 {
+  font-size: 2.2rem;
+  margin-bottom: 1rem;
+}
+
+.hero p {
+  font-size: 1.1rem;
+  color: var(--color-muted);
+  max-width: 700px;
+  margin: 0 auto 2rem;
+}
+
+.btn-primary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  background: linear-gradient(135deg, var(--color-primary), var(--color-primary-dark));
+  color: white;
+  border: none;
+  border-radius: 999px;
+  padding: 0.85rem 1.8rem;
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.btn-primary:hover,
+.btn-primary:focus {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 25px rgba(63, 81, 181, 0.25);
+}
+
+main {
+  max-width: 900px;
+  margin: 2rem auto 4rem;
+  padding: 0 1.25rem 3rem;
+  background: white;
+  border-radius: 18px;
+  box-shadow: 0 25px 45px rgba(15, 23, 42, 0.08);
+}
+
+main h2,
+main h3 {
+  color: var(--color-primary-dark);
+}
+
+main h2 {
+  margin-top: 0;
+}
+
+main h3 {
+  margin-top: 2rem;
+}
+
+main p,
+main li {
+  color: var(--color-muted);
+}
+
+main ul {
+  padding-left: 1.25rem;
+}
+
+.site-footer {
+  background: var(--color-footer);
+  color: var(--color-footer-text);
+  padding: 2.5rem 1.25rem;
+  margin-top: 4rem;
+}
+
+.site-footer a {
+  color: inherit;
+}
+
+.site-footer .footer-content {
+  max-width: 1100px;
+  margin: 0 auto;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.site-footer nav {
+  display: flex;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.site-footer nav a {
+  font-weight: 600;
+  opacity: 0.85;
+}
+
+.site-footer nav a:hover,
+.site-footer nav a:focus {
+  opacity: 1;
+}
+
+.manage-cookies {
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.55);
+  color: var(--color-footer-text);
+  padding: 0.65rem 1.5rem;
+  border-radius: 999px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.manage-cookies:hover,
+.manage-cookies:focus {
+  background: white;
+  color: var(--color-footer);
+}
+
+.site-footer p {
+  margin: 0;
+  max-width: 1100px;
+  margin: 1.5rem auto 0;
+  font-size: 0.9rem;
+  opacity: 0.7;
+}
+
+.cookie-banner {
+  position: fixed;
+  inset: auto 1.25rem 1.25rem 1.25rem;
+  background: white;
+  border-radius: 18px;
+  box-shadow: 0 30px 60px rgba(15, 23, 42, 0.15);
+  padding: 2rem;
+  max-width: 480px;
+  margin-left: auto;
+  z-index: 9999;
+  display: none;
+}
+
+.cookie-banner.is-visible {
+  display: block;
+}
+
+.cookie-banner__title {
+  margin-top: 0;
+  margin-bottom: 0.75rem;
+  font-size: 1.35rem;
+}
+
+.cookie-banner__intro {
+  margin-top: 0;
+  color: var(--color-muted);
+}
+
+.cookie-options {
+  background: var(--color-background);
+  border-radius: 14px;
+  padding: 1rem;
+  margin: 1rem 0 1.5rem;
+  border: 1px solid var(--color-border);
+}
+
+.cookie-option {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.65rem 0;
+}
+
+.cookie-option + .cookie-option {
+  border-top: 1px solid var(--color-border);
+}
+
+.cookie-option label {
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.cookie-option p {
+  margin: 0.25rem 0 0;
+  font-size: 0.85rem;
+  color: var(--color-muted);
+}
+
+.cookie-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.cookie-actions button {
+  flex: 1 1 140px;
+  border-radius: 999px;
+  padding: 0.75rem 1.25rem;
+  font-weight: 600;
+  cursor: pointer;
+  border: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.cookie-actions button:hover,
+.cookie-actions button:focus {
+  transform: translateY(-1px);
+  box-shadow: 0 14px 28px rgba(63, 81, 181, 0.2);
+}
+
+.cookie-actions .btn-accept {
+  background: var(--color-primary);
+  color: white;
+}
+
+.cookie-actions .btn-reject {
+  background: #e2e8f0;
+  color: var(--color-text);
+}
+
+.cookie-actions .btn-save {
+  background: white;
+  border: 1px solid var(--color-border);
+  color: var(--color-text);
+}
+
+.cookie-banner[data-mode="manage"] .cookie-banner__title {
+  color: var(--color-primary-dark);
+}
+
+.legal-page-header {
+  margin-bottom: 2rem;
+}
+
+.legal-page-header h2 {
+  font-size: 2rem;
+}
+
+.legal-page-header p {
+  color: var(--color-muted);
+}
+
+@media (max-width: 720px) {
+  .header-inner,
+  .site-footer .footer-content {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  nav ul {
+    flex-wrap: wrap;
+    gap: 1rem;
+  }
+
+  .cookie-banner {
+    inset: auto 1rem 1rem 1rem;
+    max-width: none;
+  }
+
+  .cookie-actions button {
+    flex: 1 1 100%;
+  }
+}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,0 +1,155 @@
+(function () {
+  const STORAGE_KEY = "cookie-consent";
+
+  function ready(fn) {
+    if (document.readyState !== "loading") {
+      fn();
+    } else {
+      document.addEventListener("DOMContentLoaded", fn);
+    }
+  }
+
+  function getStoredPreferences() {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      return stored ? JSON.parse(stored) : null;
+    } catch (error) {
+      console.warn("Impossible de lire les préférences cookies", error);
+      return null;
+    }
+  }
+
+  function storePreferences(preferences) {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(preferences));
+    } catch (error) {
+      console.warn("Impossible d'enregistrer les préférences cookies", error);
+    }
+  }
+
+  function applyPreferences(preferences) {
+    document.documentElement.dataset.cookieAnalytics = preferences.analytics;
+  }
+
+  function updateBannerCopy(banner, mode) {
+    const title = banner.querySelector("[data-banner-title]");
+    const text = banner.querySelector("[data-banner-text]");
+    if (!title || !text) return;
+
+    if (mode === "manage") {
+      title.textContent = "Gérer mes préférences cookies";
+      text.textContent =
+        "Vous pouvez ajuster à tout moment vos préférences concernant les traceurs utilisés pour améliorer notre service.";
+    } else {
+      title.textContent = "Nous respectons votre vie privée";
+      text.textContent =
+        "Nous utilisons des cookies pour assurer le bon fonctionnement du site et mesurer l'audience de nos audits marketing.";
+    }
+  }
+
+  function toggleBanner(banner, show, mode) {
+    if (!banner) return;
+    if (show) {
+      banner.dataset.mode = mode || "prompt";
+      updateBannerCopy(banner, banner.dataset.mode);
+      banner.classList.add("is-visible");
+      document.body.classList.add("no-scroll");
+      const focusable = banner.querySelector("button");
+      if (focusable) {
+        try {
+          focusable.focus({ preventScroll: true });
+        } catch (error) {
+          focusable.focus();
+        }
+      }
+    } else {
+      banner.classList.remove("is-visible");
+      document.body.classList.remove("no-scroll");
+    }
+  }
+
+  function collectPreferences(container) {
+    const toggles = container.querySelectorAll("[data-cookie-toggle]");
+    return Array.from(toggles).reduce(
+      (prefs, toggle) => {
+        const category = toggle.getAttribute("data-cookie-toggle");
+        prefs[category] = toggle.checked;
+        return prefs;
+      },
+      {}
+    );
+  }
+
+  function setPreferencesFromObject(container, preferences) {
+    const toggles = container.querySelectorAll("[data-cookie-toggle]");
+    toggles.forEach((toggle) => {
+      const category = toggle.getAttribute("data-cookie-toggle");
+      if (category in preferences) {
+        toggle.checked = Boolean(preferences[category]);
+      }
+    });
+  }
+
+  ready(function () {
+    const banner = document.querySelector(".cookie-banner");
+    if (!banner) {
+      return;
+    }
+
+    const manageButtons = document.querySelectorAll(".manage-cookies");
+    const acceptButton = banner.querySelector('[data-action="accept"]');
+    const rejectButton = banner.querySelector('[data-action="reject"]');
+    const saveButton = banner.querySelector('[data-action="save"]');
+    const preferencesContainer = banner.querySelector(".cookie-options");
+
+    const storedPrefs = getStoredPreferences();
+    if (storedPrefs) {
+      setPreferencesFromObject(preferencesContainer, storedPrefs);
+      applyPreferences(storedPrefs);
+    } else {
+      toggleBanner(banner, true, "prompt");
+    }
+
+    manageButtons.forEach((button) => {
+      button.addEventListener("click", () => {
+        setPreferencesFromObject(preferencesContainer, getStoredPreferences() || { analytics: false });
+        toggleBanner(banner, true, "manage");
+      });
+    });
+
+    if (acceptButton) {
+      acceptButton.addEventListener("click", () => {
+        const prefs = { analytics: true };
+        setPreferencesFromObject(preferencesContainer, prefs);
+        storePreferences(prefs);
+        applyPreferences(prefs);
+        toggleBanner(banner, false);
+      });
+    }
+
+    if (rejectButton) {
+      rejectButton.addEventListener("click", () => {
+        const prefs = { analytics: false };
+        setPreferencesFromObject(preferencesContainer, prefs);
+        storePreferences(prefs);
+        applyPreferences(prefs);
+        toggleBanner(banner, false);
+      });
+    }
+
+    if (saveButton) {
+      saveButton.addEventListener("click", () => {
+        const prefs = collectPreferences(preferencesContainer);
+        storePreferences(prefs);
+        applyPreferences(prefs);
+        toggleBanner(banner, false);
+      });
+    }
+
+    banner.addEventListener("keydown", (event) => {
+      if (event.key === "Escape") {
+        toggleBanner(banner, false);
+      }
+    });
+  });
+})();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Audit Marketing - Optimisez votre visibilité</title>
+    <link rel="stylesheet" href="/assets/css/styles.css" />
+  </head>
+  <body>
+    <header>
+      <div class="header-inner">
+        <div class="branding">
+          <h1>Audit Marketing</h1>
+          <p>Optimisez vos campagnes digitales grâce à nos analyses sur mesure.</p>
+        </div>
+        <nav aria-label="Navigation principale">
+          <ul>
+            <li><a href="#services">Services</a></li>
+            <li><a href="#methodologie">Méthodologie</a></li>
+            <li><a href="#contact">Contact</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <section class="hero">
+      <h2>Identifiez vos leviers de croissance en moins de 7 jours</h2>
+      <p>
+        Notre équipe réalise un audit complet de vos assets marketing pour détecter les opportunités
+        d'amélioration rapide. Recevez un rapport clair, actionnable et priorisé pour booster votre retour sur investissement.
+      </p>
+      <a class="btn-primary" href="#contact">Demander un audit personnalisé</a>
+    </section>
+
+    <main>
+      <section id="services" class="legal-page-section">
+        <h2>Ce que nous analysons</h2>
+        <p>
+          Nous examinons vos campagnes d'acquisition payantes, vos tunnels de conversion et vos performances CRM pour
+          construire un plan d'optimisation global.
+        </p>
+        <ul>
+          <li>Structure et ciblage de vos campagnes publicitaires.</li>
+          <li>Performance de vos pages d'atterrissage et de vos séquences e-mail.</li>
+          <li>Qualité des données de suivi et gouvernance analytics.</li>
+        </ul>
+      </section>
+
+      <section id="methodologie" class="legal-page-section">
+        <h2>Notre méthodologie</h2>
+        <p>
+          Nous combinons benchmarks sectoriels, analyses quantitatives et entretiens avec vos équipes pour livrer un plan
+          priorisé et directement activable. Chaque audit inclut un accompagnement de restitution pour garantir
+          l'appropriation des recommandations.
+        </p>
+      </section>
+
+      <section id="contact" class="legal-page-section">
+        <h2>Parlons de votre prochaine étape</h2>
+        <p>
+          Envoyez-nous un message à <a href="mailto:contact@audit-marketing.fr">contact@audit-marketing.fr</a> pour démarrer.
+          Nous revenons vers vous sous 24 heures ouvrées.
+        </p>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="footer-content">
+        <nav aria-label="Liens légaux">
+          <a href="/legal/mentions-legales/">Mentions légales</a>
+          <a href="/legal/terms/">Conditions d'utilisation</a>
+          <a href="/legal/privacy/">Politique de confidentialité</a>
+          <a href="/legal/cookies/">Politique cookies</a>
+        </nav>
+        <button type="button" class="manage-cookies">Gérer mes cookies</button>
+      </div>
+      <p>&copy; 2024 Audit Marketing. Tous droits réservés.</p>
+    </footer>
+
+    <div class="cookie-banner" role="dialog" aria-modal="true" aria-live="polite">
+      <h2 class="cookie-banner__title" data-banner-title>Nous respectons votre vie privée</h2>
+      <p class="cookie-banner__intro" data-banner-text>
+        Nous utilisons des cookies pour assurer le bon fonctionnement du site et mesurer l'audience de nos audits marketing.
+      </p>
+      <div class="cookie-options">
+        <div class="cookie-option">
+          <div>
+            <label>Essentiels (obligatoires)</label>
+            <p>Indispensables pour la sécurité, la navigation et la sauvegarde de vos préférences.</p>
+          </div>
+          <div>
+            <input type="checkbox" checked disabled aria-disabled="true" />
+          </div>
+        </div>
+        <div class="cookie-option">
+          <div>
+            <label for="analytics-toggle">Mesure d'audience</label>
+            <p>Nous aide à comprendre les performances de nos recommandations et à améliorer l'expérience.</p>
+          </div>
+          <div>
+            <input id="analytics-toggle" type="checkbox" data-cookie-toggle="analytics" />
+          </div>
+        </div>
+      </div>
+      <div class="cookie-actions">
+        <button type="button" class="btn-reject" data-action="reject">Refuser tout</button>
+        <button type="button" class="btn-accept" data-action="accept">Tout accepter</button>
+        <button type="button" class="btn-save" data-action="save">Enregistrer mes choix</button>
+      </div>
+    </div>
+
+    <script src="/assets/js/app.js" defer></script>
+  </body>
+</html>

--- a/legal/cookies/index.html
+++ b/legal/cookies/index.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Politique cookies - Audit Marketing</title>
+    <link rel="stylesheet" href="/assets/css/styles.css" />
+  </head>
+  <body>
+    <header>
+      <div class="header-inner">
+        <div class="branding">
+          <h1>Audit Marketing</h1>
+          <p>Politique de gestion des cookies.</p>
+        </div>
+        <nav aria-label="Navigation principale">
+          <ul>
+            <li><a href="/">Accueil</a></li>
+            <li><a href="/legal/privacy/">Confidentialité</a></li>
+            <li><a href="/legal/terms/">CGU</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <div class="legal-page-header">
+        <h2>Politique cookies</h2>
+        <p>Comprenez l'usage des traceurs et comment ajuster vos préférences.</p>
+      </div>
+
+      <section>
+        <h3>Catégories de cookies</h3>
+        <ul>
+          <li>
+            <strong>Essentiels :</strong> nécessaires au fonctionnement du site et à la conservation de vos choix. Ils ne peuvent
+            pas être désactivés.
+          </li>
+          <li>
+            <strong>Mesure d'audience :</strong> nous aide à comprendre comment nos contenus sont consultés pour améliorer nos
+            services.
+          </li>
+        </ul>
+      </section>
+
+      <section>
+        <h3>Durée de conservation</h3>
+        <p>
+          Les cookies de mesure d'audience sont conservés pendant une durée maximale de 13 mois. Votre choix concernant les
+          cookies est conservé pendant 6 mois dans votre navigateur.
+        </p>
+      </section>
+
+      <section>
+        <h3>Modifier votre consentement</h3>
+        <p>
+          Vous pouvez modifier vos préférences à tout moment en cliquant sur le bouton <strong>Gérer mes cookies</strong>
+          présent en bas de page. Ce bouton ré-ouvre la bannière afin d'ajuster vos choix.
+        </p>
+      </section>
+
+      <section>
+        <h3>Informations complémentaires</h3>
+        <p>
+          Pour en savoir plus sur le traitement de vos données personnelles, consultez notre
+          <a href="/legal/privacy/">Politique de confidentialité</a>.
+        </p>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="footer-content">
+        <nav aria-label="Liens légaux">
+          <a href="/legal/mentions-legales/">Mentions légales</a>
+          <a href="/legal/terms/">Conditions d'utilisation</a>
+          <a href="/legal/privacy/">Politique de confidentialité</a>
+          <a href="/legal/cookies/">Politique cookies</a>
+        </nav>
+        <button type="button" class="manage-cookies">Gérer mes cookies</button>
+      </div>
+      <p>&copy; 2024 Audit Marketing. Tous droits réservés.</p>
+    </footer>
+
+    <div class="cookie-banner" role="dialog" aria-modal="true" aria-live="polite">
+      <h2 class="cookie-banner__title" data-banner-title>Nous respectons votre vie privée</h2>
+      <p class="cookie-banner__intro" data-banner-text>
+        Nous utilisons des cookies pour assurer le bon fonctionnement du site et mesurer l'audience de nos audits marketing.
+      </p>
+      <div class="cookie-options">
+        <div class="cookie-option">
+          <div>
+            <label>Essentiels (obligatoires)</label>
+            <p>Indispensables pour la sécurité, la navigation et la sauvegarde de vos préférences.</p>
+          </div>
+          <div>
+            <input type="checkbox" checked disabled aria-disabled="true" />
+          </div>
+        </div>
+        <div class="cookie-option">
+          <div>
+            <label for="analytics-toggle">Mesure d'audience</label>
+            <p>Nous aide à comprendre les performances de nos recommandations et à améliorer l'expérience.</p>
+          </div>
+          <div>
+            <input id="analytics-toggle" type="checkbox" data-cookie-toggle="analytics" />
+          </div>
+        </div>
+      </div>
+      <div class="cookie-actions">
+        <button type="button" class="btn-reject" data-action="reject">Refuser tout</button>
+        <button type="button" class="btn-accept" data-action="accept">Tout accepter</button>
+        <button type="button" class="btn-save" data-action="save">Enregistrer mes choix</button>
+      </div>
+    </div>
+
+    <script src="/assets/js/app.js" defer></script>
+  </body>
+</html>

--- a/legal/mentions-legales/index.html
+++ b/legal/mentions-legales/index.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Mentions légales - Audit Marketing</title>
+    <link rel="stylesheet" href="/assets/css/styles.css" />
+  </head>
+  <body>
+    <header>
+      <div class="header-inner">
+        <div class="branding">
+          <h1>Audit Marketing</h1>
+          <p>Mentions légales et informations réglementaires.</p>
+        </div>
+        <nav aria-label="Navigation principale">
+          <ul>
+            <li><a href="/">Accueil</a></li>
+            <li><a href="/legal/terms/">CGU</a></li>
+            <li><a href="/legal/privacy/">Confidentialité</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <div class="legal-page-header">
+        <h2>Mentions légales</h2>
+        <p>Informations obligatoires conformément à la loi n° 2004-575 du 21 juin 2004.</p>
+      </div>
+
+      <section>
+        <h3>Éditeur du site</h3>
+        <p>
+          Audit Marketing, société par actions simplifiée au capital de &lt;montant&gt; €, immatriculée au RCS de Paris sous le
+          numéro SIREN <strong>000&nbsp;000&nbsp;000</strong>, dont le siège social est situé au 10 rue de l'Analyse, 75000 Paris.
+        </p>
+        <p>Adresse e-mail : <a href="mailto:contact@audit-marketing.fr">contact@audit-marketing.fr</a></p>
+        <p>Téléphone : +33 (0)1 23 45 67 89</p>
+      </section>
+
+      <section>
+        <h3>Directeur de la publication</h3>
+        <p>
+          <strong>Nom Prénom</strong>, en qualité de Directeur ou Directrice de la publication, est responsable de la publication
+          des contenus proposés sur le site.
+        </p>
+      </section>
+
+      <section>
+        <h3>Hébergement</h3>
+        <p>
+          Le site est hébergé par <strong>Nom de l'hébergeur</strong>, société enregistrée au RCS sous le numéro SIREN
+          <strong>111&nbsp;111&nbsp;111</strong>, dont le siège social est situé au 99 avenue du Cloud, 69000 Lyon.
+        </p>
+        <p>Téléphone : +33 (0)4 56 78 90 12</p>
+        <p>Site web : <a href="https://www.hebergeur-exemple.fr">www.hebergeur-exemple.fr</a></p>
+      </section>
+
+      <section>
+        <h3>Propriété intellectuelle</h3>
+        <p>
+          L'ensemble des éléments graphiques, textes, logos et contenus présents sur le site sont protégés par le droit de la
+          propriété intellectuelle. Toute reproduction totale ou partielle sans autorisation écrite préalable est interdite.
+        </p>
+      </section>
+
+      <section>
+        <h3>Contact</h3>
+        <p>
+          Pour toute question relative aux mentions légales, vous pouvez nous écrire à l'adresse suivante : Audit Marketing,
+          Service juridique, 10 rue de l'Analyse, 75000 Paris.
+        </p>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="footer-content">
+        <nav aria-label="Liens légaux">
+          <a href="/legal/mentions-legales/">Mentions légales</a>
+          <a href="/legal/terms/">Conditions d'utilisation</a>
+          <a href="/legal/privacy/">Politique de confidentialité</a>
+          <a href="/legal/cookies/">Politique cookies</a>
+        </nav>
+        <button type="button" class="manage-cookies">Gérer mes cookies</button>
+      </div>
+      <p>&copy; 2024 Audit Marketing. Tous droits réservés.</p>
+    </footer>
+
+    <div class="cookie-banner" role="dialog" aria-modal="true" aria-live="polite">
+      <h2 class="cookie-banner__title" data-banner-title>Nous respectons votre vie privée</h2>
+      <p class="cookie-banner__intro" data-banner-text>
+        Nous utilisons des cookies pour assurer le bon fonctionnement du site et mesurer l'audience de nos audits marketing.
+      </p>
+      <div class="cookie-options">
+        <div class="cookie-option">
+          <div>
+            <label>Essentiels (obligatoires)</label>
+            <p>Indispensables pour la sécurité, la navigation et la sauvegarde de vos préférences.</p>
+          </div>
+          <div>
+            <input type="checkbox" checked disabled aria-disabled="true" />
+          </div>
+        </div>
+        <div class="cookie-option">
+          <div>
+            <label for="analytics-toggle">Mesure d'audience</label>
+            <p>Nous aide à comprendre les performances de nos recommandations et à améliorer l'expérience.</p>
+          </div>
+          <div>
+            <input id="analytics-toggle" type="checkbox" data-cookie-toggle="analytics" />
+          </div>
+        </div>
+      </div>
+      <div class="cookie-actions">
+        <button type="button" class="btn-reject" data-action="reject">Refuser tout</button>
+        <button type="button" class="btn-accept" data-action="accept">Tout accepter</button>
+        <button type="button" class="btn-save" data-action="save">Enregistrer mes choix</button>
+      </div>
+    </div>
+
+    <script src="/assets/js/app.js" defer></script>
+  </body>
+</html>

--- a/legal/privacy/index.html
+++ b/legal/privacy/index.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Politique de confidentialité - Audit Marketing</title>
+    <link rel="stylesheet" href="/assets/css/styles.css" />
+  </head>
+  <body>
+    <header>
+      <div class="header-inner">
+        <div class="branding">
+          <h1>Audit Marketing</h1>
+          <p>Politique de confidentialité et protection des données.</p>
+        </div>
+        <nav aria-label="Navigation principale">
+          <ul>
+            <li><a href="/">Accueil</a></li>
+            <li><a href="/legal/terms/">CGU</a></li>
+            <li><a href="/legal/cookies/">Cookies</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <div class="legal-page-header">
+        <h2>Politique de confidentialité</h2>
+        <p>Comment et pourquoi nous traitons vos données personnelles.</p>
+      </div>
+
+      <section>
+        <h3>Bases légales du traitement</h3>
+        <p>
+          Nous traitons vos données sur la base de l'exécution contractuelle lorsqu'il s'agit de réaliser nos audits et
+          recommandations. Certains traitements reposent également sur notre intérêt légitime à améliorer nos services, ou sur
+          votre consentement pour la communication marketing.
+        </p>
+      </section>
+
+      <section>
+        <h3>Finalités poursuivies</h3>
+        <ul>
+          <li>Préparer, réaliser et livrer les rapports d'audit marketing.</li>
+          <li>Assurer le suivi client, la facturation et l'amélioration continue de notre méthodologie.</li>
+          <li>Mesurer l'audience du site et la performance de nos actions marketing lorsque vous y consentez.</li>
+        </ul>
+      </section>
+
+      <section>
+        <h3>Durée de conservation</h3>
+        <p>
+          Les fichiers transmis pour la réalisation de l'audit, ainsi que les rapports délivrés, sont conservés pendant une
+          durée maximale de <strong>30 jours</strong> après livraison, sauf obligation légale supérieure. Les données de facturation
+          sont conservées pendant la durée légale applicable.
+        </p>
+      </section>
+
+      <section>
+        <h3>Vos droits RGPD</h3>
+        <p>
+          Vous disposez des droits d'accès, de rectification, d'effacement, d'opposition, de limitation et de portabilité de vos
+          données. Vous pouvez également retirer votre consentement à tout moment lorsque le traitement repose sur celui-ci.
+        </p>
+      </section>
+
+      <section>
+        <h3>Procédure d'exercice des droits</h3>
+        <p>
+          Pour exercer vos droits, adressez votre demande à <a href="mailto:privacy@audit-marketing.fr">privacy@audit-marketing.fr</a>
+          ou par courrier à Audit Marketing, Délégué à la protection des données, 10 rue de l'Analyse, 75000 Paris. Joignez une
+          pièce d'identité pour que nous puissions vérifier votre identité. Nous vous répondrons dans un délai d'un mois.
+        </p>
+      </section>
+
+      <section>
+        <h3>Sous-traitants et transferts</h3>
+        <p>
+          Nous faisons appel à des prestataires spécialisés pour l'hébergement sécurisé des données et l'envoi de communications.
+          Ils n'agissent que sur instruction documentée et sont soumis à des obligations de confidentialité.
+        </p>
+        <p>
+          Les données peuvent être transférées hors de l'Union européenne lorsque nos sous-traitants sont situés dans un pays
+          offrant un niveau de protection adéquat ou encadré par des clauses contractuelles types approuvées par la Commission
+          européenne.
+        </p>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="footer-content">
+        <nav aria-label="Liens légaux">
+          <a href="/legal/mentions-legales/">Mentions légales</a>
+          <a href="/legal/terms/">Conditions d'utilisation</a>
+          <a href="/legal/privacy/">Politique de confidentialité</a>
+          <a href="/legal/cookies/">Politique cookies</a>
+        </nav>
+        <button type="button" class="manage-cookies">Gérer mes cookies</button>
+      </div>
+      <p>&copy; 2024 Audit Marketing. Tous droits réservés.</p>
+    </footer>
+
+    <div class="cookie-banner" role="dialog" aria-modal="true" aria-live="polite">
+      <h2 class="cookie-banner__title" data-banner-title>Nous respectons votre vie privée</h2>
+      <p class="cookie-banner__intro" data-banner-text>
+        Nous utilisons des cookies pour assurer le bon fonctionnement du site et mesurer l'audience de nos audits marketing.
+      </p>
+      <div class="cookie-options">
+        <div class="cookie-option">
+          <div>
+            <label>Essentiels (obligatoires)</label>
+            <p>Indispensables pour la sécurité, la navigation et la sauvegarde de vos préférences.</p>
+          </div>
+          <div>
+            <input type="checkbox" checked disabled aria-disabled="true" />
+          </div>
+        </div>
+        <div class="cookie-option">
+          <div>
+            <label for="analytics-toggle">Mesure d'audience</label>
+            <p>Nous aide à comprendre les performances de nos recommandations et à améliorer l'expérience.</p>
+          </div>
+          <div>
+            <input id="analytics-toggle" type="checkbox" data-cookie-toggle="analytics" />
+          </div>
+        </div>
+      </div>
+      <div class="cookie-actions">
+        <button type="button" class="btn-reject" data-action="reject">Refuser tout</button>
+        <button type="button" class="btn-accept" data-action="accept">Tout accepter</button>
+        <button type="button" class="btn-save" data-action="save">Enregistrer mes choix</button>
+      </div>
+    </div>
+
+    <script src="/assets/js/app.js" defer></script>
+  </body>
+</html>

--- a/legal/terms/index.html
+++ b/legal/terms/index.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Conditions générales d'utilisation - Audit Marketing</title>
+    <link rel="stylesheet" href="/assets/css/styles.css" />
+  </head>
+  <body>
+    <header>
+      <div class="header-inner">
+        <div class="branding">
+          <h1>Audit Marketing</h1>
+          <p>Conditions générales d'utilisation (CGU).</p>
+        </div>
+        <nav aria-label="Navigation principale">
+          <ul>
+            <li><a href="/">Accueil</a></li>
+            <li><a href="/legal/privacy/">Confidentialité</a></li>
+            <li><a href="/legal/cookies/">Cookies</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <div class="legal-page-header">
+        <h2>Conditions générales d'utilisation</h2>
+        <p>Version en vigueur au 1er janvier 2024.</p>
+      </div>
+
+      <section>
+        <h3>1. Objet</h3>
+        <p>
+          Les présentes conditions générales d'utilisation (CGU) régissent l'accès et l'utilisation du service en ligne d'audit
+          marketing proposé par Audit Marketing. Le service consiste à analyser vos données marketing et à fournir un rapport
+          d'audit accompagné de recommandations opérationnelles.
+        </p>
+      </section>
+
+      <section>
+        <h3>2. Description du service</h3>
+        <p>
+          Le service permet aux utilisateurs de soumettre des informations relatives à leurs campagnes, contenus et données
+          analytiques. Nos experts traitent ces informations pour produire un diagnostic personnalisé, un plan d'action priorisé
+          et un accompagnement de restitution.
+        </p>
+      </section>
+
+      <section>
+        <h3>3. Limites et responsabilités</h3>
+        <p>
+          Les recommandations délivrées reposent sur les informations fournies par l'utilisateur. Audit Marketing ne saurait être
+          tenu responsable des conséquences résultant d'informations incomplètes, inexactes ou obsolètes. L'utilisateur conserve
+          la maîtrise de ses décisions stratégiques et opérationnelles.
+        </p>
+      </section>
+
+      <section>
+        <h3>4. Propriété des contenus</h3>
+        <p>
+          Les rapports, fichiers et recommandations remis restent la propriété d'Audit Marketing jusqu'au paiement complet de la
+          prestation. À compter de ce paiement, une licence non exclusive d'utilisation est accordée à l'utilisateur pour ses
+          besoins internes.
+        </p>
+        <p>
+          L'utilisateur garantit disposer des droits nécessaires sur les documents transmis pour permettre l'exécution de
+          l'audit.
+        </p>
+      </section>
+
+      <section>
+        <h3>5. Responsabilité</h3>
+        <p>
+          Audit Marketing met en œuvre les moyens raisonnables pour assurer la disponibilité du service. Toutefois, la société ne
+          peut être tenue responsable des interruptions liées à la maintenance, aux mises à jour ou aux cas de force majeure.
+        </p>
+        <p>
+          En aucun cas la responsabilité d'Audit Marketing ne saurait excéder le montant total payé par l'utilisateur pour la
+          prestation à l'origine de la réclamation.
+        </p>
+      </section>
+
+      <section>
+        <h3>6. Loi applicable</h3>
+        <p>
+          Les présentes CGU sont soumises au droit français. Tout différend relatif à leur interprétation ou à leur exécution
+          sera soumis aux tribunaux compétents du ressort de la Cour d'appel de Paris.
+        </p>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="footer-content">
+        <nav aria-label="Liens légaux">
+          <a href="/legal/mentions-legales/">Mentions légales</a>
+          <a href="/legal/terms/">Conditions d'utilisation</a>
+          <a href="/legal/privacy/">Politique de confidentialité</a>
+          <a href="/legal/cookies/">Politique cookies</a>
+        </nav>
+        <button type="button" class="manage-cookies">Gérer mes cookies</button>
+      </div>
+      <p>&copy; 2024 Audit Marketing. Tous droits réservés.</p>
+    </footer>
+
+    <div class="cookie-banner" role="dialog" aria-modal="true" aria-live="polite">
+      <h2 class="cookie-banner__title" data-banner-title>Nous respectons votre vie privée</h2>
+      <p class="cookie-banner__intro" data-banner-text>
+        Nous utilisons des cookies pour assurer le bon fonctionnement du site et mesurer l'audience de nos audits marketing.
+      </p>
+      <div class="cookie-options">
+        <div class="cookie-option">
+          <div>
+            <label>Essentiels (obligatoires)</label>
+            <p>Indispensables pour la sécurité, la navigation et la sauvegarde de vos préférences.</p>
+          </div>
+          <div>
+            <input type="checkbox" checked disabled aria-disabled="true" />
+          </div>
+        </div>
+        <div class="cookie-option">
+          <div>
+            <label for="analytics-toggle">Mesure d'audience</label>
+            <p>Nous aide à comprendre les performances de nos recommandations et à améliorer l'expérience.</p>
+          </div>
+          <div>
+            <input id="analytics-toggle" type="checkbox" data-cookie-toggle="analytics" />
+          </div>
+        </div>
+      </div>
+      <div class="cookie-actions">
+        <button type="button" class="btn-reject" data-action="reject">Refuser tout</button>
+        <button type="button" class="btn-accept" data-action="accept">Tout accepter</button>
+        <button type="button" class="btn-save" data-action="save">Enregistrer mes choix</button>
+      </div>
+    </div>
+
+    <script src="/assets/js/app.js" defer></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- create static marketing landing page with shared footer and cookie banner
- add dedicated legal pages for mentions légales, CGU, confidentialité et cookies
- implement reusable cookie consent script to store preferences and reopen the banner for management

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d53c0ded188329aeaecc9ba78c0ee0