### PR TITLE
Add marketing pages with mocked auth and Playwright test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+playwright-report/
+test-results/
+.env
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-# Projet_Site_Marketing
+# Projet Site Marketing
+
+Cette application propose un mini site marketing avec un système de connexion simulé. Elle comporte :
+
+- Un header avec logo typographique, liens vers les pages « Accueil », « Dashboard », « Mon compte » et un bouton contextuel « Se connecter / Se déconnecter ».
+- Une page d'accueil présentant brièvement le service avec un bouton d'accès à la connexion.
+- Un tableau de bord qui salue l'utilisateur connecté et redirige vers la page de connexion si l'utilisateur n'est pas authentifié.
+- Une page de connexion qui simule une authentification OAuth et crée un cookie de session.
+
+## Démarrage
+
+```bash
+npm install
+npm run dev
+```
+
+L'application est disponible sur `http://localhost:3000`.
+
+## Tests
+
+Des tests Playwright vérifient le scénario d'accès au tableau de bord. Pour les exécuter :
+
+```bash
+npx playwright install --with-deps
+npm test
+```
+
+Le test `Accès au tableau de bord` contrôle qu'un visiteur non connecté est redirigé vers `/login`, puis qu'une fois la connexion OAuth simulée effectuée, il accède bien au tableau de bord.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "projet_site_marketing",
+  "version": "1.0.0",
+  "description": "Site marketing avec authentification simulée",
+  "main": "server.js",
+  "scripts": {
+    "dev": "node server.js",
+    "start": "node server.js",
+    "test": "playwright test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "cookie-parser": "^1.4.6",
+    "ejs": "^3.1.9",
+    "express": "^4.19.2"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.43.1"
+  }
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  timeout: 30_000,
+  expect: {
+    timeout: 5_000,
+  },
+  fullyParallel: true,
+  reporter: [['list']],
+  use: {
+    baseURL: 'http://127.0.0.1:3000',
+    trace: 'on-first-retry',
+    headless: true,
+  },
+  webServer: {
+    command: 'node server.js',
+    url: 'http://127.0.0.1:3000',
+    reuseExistingServer: !process.env.CI,
+    stdout: 'pipe',
+    stderr: 'pipe',
+    timeout: 120_000,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,186 @@
+:root {
+  --color-primary: #3b82f6;
+  --color-secondary: #1f2937;
+  --color-background: #f3f4f6;
+  --color-surface: #ffffff;
+  --color-text: #111827;
+  --color-muted: #6b7280;
+  font-family: 'Inter', 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--color-background);
+  color: var(--color-text);
+}
+
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 2rem;
+  background: var(--color-surface);
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.logo {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 700;
+  font-size: 1.1rem;
+}
+
+.logo-mark {
+  font-size: 1.4rem;
+  color: var(--color-primary);
+}
+
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.nav-link {
+  color: var(--color-muted);
+  text-decoration: none;
+  font-weight: 500;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.375rem;
+  transition: color 0.2s ease, background-color 0.2s ease;
+}
+
+.nav-link:hover,
+.nav-link:focus {
+  color: var(--color-secondary);
+  background: rgba(59, 130, 246, 0.12);
+}
+
+.nav-link.active {
+  color: var(--color-secondary);
+  background: rgba(59, 130, 246, 0.2);
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+}
+
+.header-actions form {
+  margin: 0;
+}
+
+main.content {
+  padding: 3rem 2rem;
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+.hero {
+  background: var(--color-surface);
+  border-radius: 1rem;
+  padding: 3rem;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.08);
+}
+
+.hero h1 {
+  font-size: 2.5rem;
+  margin-bottom: 1rem;
+}
+
+.hero p {
+  font-size: 1.1rem;
+  color: var(--color-muted);
+  line-height: 1.6;
+  margin-bottom: 2rem;
+}
+
+.panel {
+  background: var(--color-surface);
+  border-radius: 1rem;
+  padding: 2.5rem;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.08);
+}
+
+.panel h1 {
+  margin-top: 0;
+  margin-bottom: 1rem;
+}
+
+.panel p {
+  color: var(--color-muted);
+  line-height: 1.6;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.5rem;
+  border-radius: 0.75rem;
+  font-weight: 600;
+  text-decoration: none;
+  cursor: pointer;
+  border: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.button.primary {
+  background: linear-gradient(135deg, #3b82f6, #6366f1);
+  color: white;
+  box-shadow: 0 10px 20px rgba(99, 102, 241, 0.3);
+}
+
+.button.primary:hover,
+.button.primary:focus {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 22px rgba(99, 102, 241, 0.35);
+}
+
+.button.secondary {
+  background: rgba(15, 23, 42, 0.08);
+  color: var(--color-secondary);
+}
+
+.button.secondary:hover,
+.button.secondary:focus {
+  background: rgba(15, 23, 42, 0.16);
+}
+
+form button.button {
+  width: 100%;
+}
+
+@media (max-width: 768px) {
+  .site-header {
+    flex-wrap: wrap;
+    gap: 1rem;
+  }
+
+  .nav-links {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .header-actions {
+    width: 100%;
+    justify-content: flex-end;
+  }
+
+  main.content {
+    padding: 2rem 1.5rem;
+  }
+
+  .hero,
+  .panel {
+    padding: 2rem;
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,81 @@
+const express = require('express');
+const path = require('path');
+const cookieParser = require('cookie-parser');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+app.set('view engine', 'ejs');
+app.set('views', path.join(__dirname, 'views'));
+
+app.use(cookieParser());
+app.use(express.urlencoded({ extended: true }));
+app.use(express.static(path.join(__dirname, 'public')));
+
+app.use((req, res, next) => {
+  const userName = req.cookies.userName;
+  res.locals.user = userName ? { name: userName } : null;
+  res.locals.currentPath = req.path;
+  next();
+});
+
+app.get('/', (req, res) => {
+  res.render('index', {
+    title: 'Votre solution marketing',
+  });
+});
+
+app.get('/dashboard', (req, res) => {
+  if (!res.locals.user) {
+    return res.redirect('/login');
+  }
+
+  res.render('dashboard', {
+    title: 'Tableau de bord',
+  });
+});
+
+app.get('/account', (req, res) => {
+  if (!res.locals.user) {
+    return res.redirect('/login');
+  }
+
+  res.render('account', {
+    title: 'Mon compte',
+  });
+});
+
+app.get('/login', (req, res) => {
+  if (res.locals.user) {
+    return res.redirect('/dashboard');
+  }
+
+  res.render('login', {
+    title: 'Connexion',
+  });
+});
+
+app.post('/auth/mock', (req, res) => {
+  res.cookie('userName', 'Jean Dupont', {
+    httpOnly: false,
+    sameSite: 'lax',
+  });
+  res.redirect('/dashboard');
+});
+
+app.post('/logout', (req, res) => {
+  res.clearCookie('userName');
+  res.redirect('/');
+});
+
+app.use((req, res) => {
+  res.status(404).render('404', {
+    title: 'Page introuvable',
+  });
+});
+
+app.listen(PORT, () => {
+  console.log(`Server listening on http://localhost:${PORT}`);
+});
+
+module.exports = app;

--- a/tests/auth.spec.ts
+++ b/tests/auth.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Accès au tableau de bord', () => {
+  test('un visiteur est redirigé et peut accéder après connexion mock', async ({ page }) => {
+    await page.goto('/dashboard');
+
+    await expect(page).toHaveURL(/\/login$/);
+    await expect(page.getByRole('heading', { level: 1, name: 'Connexion' })).toBeVisible();
+
+    await page.getByRole('button', { name: 'Se connecter avec Mock OAuth' }).click();
+
+    await expect(page).toHaveURL(/\/dashboard$/);
+    await expect(page.getByRole('heading', { level: 1 })).toHaveText('Bonjour Jean Dupont');
+    await expect(page.getByRole('button', { name: 'Se déconnecter' })).toBeVisible();
+  });
+});

--- a/views/404.ejs
+++ b/views/404.ejs
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title><%= title %> | Marketing Boost</title>
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <%- include('partials/header') %>
+    <main class="content">
+      <section class="panel">
+        <h1>Page introuvable</h1>
+        <p>La page que vous cherchez n'existe pas ou a été déplacée.</p>
+        <a class="button secondary" href="/">Retour à l'accueil</a>
+      </section>
+    </main>
+  </body>
+</html>

--- a/views/account.ejs
+++ b/views/account.ejs
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title><%= title %> | Marketing Boost</title>
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <%- include('partials/header') %>
+    <main class="content">
+      <section class="panel">
+        <h1>Profil de <%= user ? user.name : '' %></h1>
+        <p>Mettez à jour vos informations personnelles et vos préférences de notification.</p>
+      </section>
+    </main>
+  </body>
+</html>

--- a/views/dashboard.ejs
+++ b/views/dashboard.ejs
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title><%= title %> | Marketing Boost</title>
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <%- include('partials/header') %>
+    <main class="content">
+      <section class="panel">
+        <h1>Bonjour <%= user ? user.name : '' %></h1>
+        <p>Voici votre tableau de bord. Retrouvez vos indicateurs clés en un coup d'œil.</p>
+      </section>
+    </main>
+  </body>
+</html>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title><%= title %> | Marketing Boost</title>
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <%- include('partials/header') %>
+    <main class="content">
+      <section class="hero">
+        <h1>Accélérez votre marketing digital</h1>
+        <p>
+          Marketing Boost centralise vos campagnes, vos audiences et vos indicateurs
+          pour vous aider à piloter votre croissance plus rapidement.
+        </p>
+        <a class="button primary" href="/login">Se connecter</a>
+      </section>
+    </main>
+  </body>
+</html>

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title><%= title %> | Marketing Boost</title>
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <%- include('partials/header') %>
+    <main class="content">
+      <section class="panel">
+        <h1>Connexion</h1>
+        <p>Authentifiez-vous pour accéder à votre tableau de bord personnalisé.</p>
+        <form method="post" action="/auth/mock">
+          <button type="submit" class="button primary">Se connecter avec Mock OAuth</button>
+        </form>
+      </section>
+    </main>
+  </body>
+</html>

--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -1,0 +1,20 @@
+<header class="site-header">
+  <div class="logo" aria-label="Logo">
+    <span class="logo-mark">⚡</span>
+    <span class="logo-text">Marketing Boost</span>
+  </div>
+  <nav class="nav-links" aria-label="Navigation principale">
+    <a href="/" class="nav-link<%= currentPath === '/' ? ' active' : '' %>">Accueil</a>
+    <a href="/dashboard" class="nav-link<%= currentPath === '/dashboard' ? ' active' : '' %>">Dashboard</a>
+    <a href="/account" class="nav-link<%= currentPath === '/account' ? ' active' : '' %>">Mon compte</a>
+  </nav>
+  <div class="header-actions">
+    <% if (user) { %>
+      <form method="post" action="/logout">
+        <button type="submit" class="button secondary">Se déconnecter</button>
+      </form>
+    <% } else { %>
+      <a href="/login" class="button primary">Se connecter</a>
+    <% } %>
+  </div>
+</header>


### PR DESCRIPTION
## Summary
- build an Express/EJS marketing site with a shared header and contextual auth button
- add public pages, dashboard gatekeeping, and mocked OAuth login/logout routes
- style the interface and document usage in the README
- configure Playwright end-to-end test covering redirect and login flow

## Testing
- ⚠️ `npm install` *(fails with 403 Forbidden from registry.npmjs.org in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d53c39ddf08329a9761765c0f80c76