### PR TITLE
feat: refresh marketing home layout

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -31,10 +31,10 @@
 
 @layer utilities {
   .shadow-soft {
-    @apply shadow-md shadow-slate-900/5;
+    @apply shadow-md;
   }
+}
 
-  .ring-focus {
-    @apply focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2;
-  }
+:where(button, a).[class*="focus-visible"] {
+  @apply ring-2 ring-primary ring-offset-2;
 }

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -47,7 +47,7 @@ function Footer() {
             <Link
               key={item.href}
               href={item.href}
-              className="transition-colors ring-focus hover:text-primary"
+              className="transition-colors focus-visible:outline-none hover:text-primary"
             >
               {item.label}
             </Link>
@@ -57,9 +57,14 @@ function Footer() {
           <p className="text-sm text-slate-500">© {year} PubLégalFR. Tous droits réservés.</p>
           <Button
             type="button"
-            variant="ghost"
+            variant="secondary"
             size="md"
-            className="w-full justify-center border border-transparent bg-muted text-sm font-medium text-slate-600 hover:bg-muted sm:w-auto"
+            className="manage-cookies w-full justify-center text-sm font-medium text-slate-600 sm:w-auto"
+            onClick={() => {
+              if (typeof document !== "undefined") {
+                document.dispatchEvent(new CustomEvent("cookie-banner:open"));
+              }
+            }}
           >
             Gérer mes cookies
           </Button>

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -8,7 +8,7 @@ const features = [
     description: "Note instantanée avec indicateurs visuels.",
     icon: (
       <svg
-        className="h-10 w-10 text-primary"
+        className="h-8 w-8 text-primary"
         viewBox="0 0 24 24"
         fill="none"
         stroke="currentColor"
@@ -26,7 +26,7 @@ const features = [
     description: "Rapport horodaté prêt à partager.",
     icon: (
       <svg
-        className="h-10 w-10 text-primary"
+        className="h-8 w-8 text-primary"
         viewBox="0 0 24 24"
         fill="none"
         stroke="currentColor"
@@ -48,7 +48,7 @@ const features = [
     description: "Suivez l’évolution de vos analyses.",
     icon: (
       <svg
-        className="h-10 w-10 text-primary"
+        className="h-8 w-8 text-primary"
         viewBox="0 0 24 24"
         fill="none"
         stroke="currentColor"
@@ -67,63 +67,34 @@ const features = [
 
 export default function Home() {
   return (
-    <div className="space-y-20 pb-16">
-      <section className="container flex flex-col items-center py-12 sm:py-16">
-        <div className="mx-auto flex max-w-3xl flex-col items-center text-center">
-          <Badge className="mb-6 bg-primary/10 text-primary">Conformité publicitaire instantanée</Badge>
+    <div className="pb-20">
+      <section className="container flex flex-col items-center py-16 text-center">
+        <div className="flex max-w-3xl flex-col items-center gap-6">
+          <Badge className="bg-primary/10 text-primary">Conformité publicitaire instantanée</Badge>
           <h1 className="text-4xl font-semibold tracking-tight text-text sm:text-5xl">
-            Analysez la <span className="text-primary">conformité</span> de vos publicités en 60 secondes
+            Analysez la conformité de vos <span className="text-primary">publicités</span> en 60 secondes
           </h1>
-          <p className="mt-4 text-lg text-slate-600">
-            Automatiser le contrôle de vos assets marketing n’a jamais été aussi simple. Déposez votre URL, et obtenez un rapport clair, actionnable et partageable.
+          <p className="text-lg text-slate-600">
+            Automatisez le contrôle de vos assets marketing : uploadez votre landing page, recevez un rapport clair, actionnable et prêt à partager.
           </p>
-          <div className="mt-6 flex w-full flex-col gap-3 sm:w-auto sm:flex-row sm:justify-center">
-            <Button href="/analyser" size="lg">
+          <div className="flex w-full flex-col gap-3 sm:w-auto sm:flex-row sm:justify-center">
+            <Button href="/analyser" size="lg" className="w-full sm:w-auto">
               Analyser une landing page
             </Button>
-            <Button href="/historique" size="lg" variant="secondary">
+            <Button
+              href="/historique"
+              size="lg"
+              variant="secondary"
+              className="w-full sm:w-auto"
+            >
               Voir un exemple de rapport
             </Button>
           </div>
         </div>
-        <div className="mt-12 w-full max-w-5xl">
-          <div className="rounded-2xl border border-border bg-white p-6 shadow-soft">
-            <div className="grid gap-6 md:grid-cols-2">
-              <div className="flex flex-col gap-4">
-                <span className="text-sm font-medium uppercase tracking-wide text-slate-500">
-                  Dernière analyse
-                </span>
-                <div className="flex items-end gap-3">
-                  <span className="text-5xl font-semibold text-primary">92</span>
-                  <span className="mb-1 text-sm font-medium text-slate-500">/100</span>
-                </div>
-                <p className="text-sm text-slate-500">
-                  Synthèse générée le 12 octobre 2024 — 3 recommandations à traiter pour atteindre la conformité totale.
-                </p>
-              </div>
-              <div className="flex items-center justify-center rounded-xl bg-gradient-to-br from-primary/10 to-primary/5 p-6">
-                <div className="w-full max-w-xs space-y-3">
-                  <div className="flex items-center justify-between rounded-lg border border-border bg-white px-4 py-3 shadow-sm">
-                    <span className="text-sm font-medium text-text">Claims juridiques</span>
-                    <span className="text-sm font-semibold text-emerald-600">Conformes</span>
-                  </div>
-                  <div className="flex items-center justify-between rounded-lg border border-border bg-white px-4 py-3 shadow-sm">
-                    <span className="text-sm font-medium text-text">Mentions obligatoires</span>
-                    <span className="text-sm font-semibold text-amber-500">À revoir</span>
-                  </div>
-                  <div className="flex items-center justify-between rounded-lg border border-border bg-white px-4 py-3 shadow-sm">
-                    <span className="text-sm font-medium text-text">Traçabilité</span>
-                    <span className="text-sm font-semibold text-primary">Optimale</span>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
       </section>
 
-      <section className="container py-12 sm:py-16">
-        <div className="grid gap-6 sm:grid-cols-3">
+      <section className="container py-12">
+        <div className="mt-10 grid grid-cols-1 gap-6 sm:grid-cols-3 md:gap-8">
           {features.map((feature) => (
             <Card key={feature.title} className="text-left">
               <div className="flex flex-col gap-4">
@@ -137,12 +108,10 @@ export default function Home() {
           ))}
         </div>
         <div className="mt-12 flex flex-col items-center gap-4 text-center text-sm text-slate-500 sm:flex-row sm:justify-center">
-          <span className="font-medium text-slate-600">Déjà utilisé par</span>
+          <span className="font-medium text-slate-600">Déjà utilisé par…</span>
           <div className="flex flex-wrap justify-center gap-3">
             {["E-commerce", "Agences", "Dropshipping"].map((label) => (
-              <Badge key={label} className="bg-muted text-sm text-slate-600">
-                {label}
-              </Badge>
+              <Badge key={label}>{label}</Badge>
             ))}
           </div>
         </div>

--- a/frontend/components/ui/badge.tsx
+++ b/frontend/components/ui/badge.tsx
@@ -6,7 +6,7 @@ export function Badge({ className, ...props }: HTMLAttributes<HTMLSpanElement>) 
   return (
     <span
       className={cn(
-        "inline-flex items-center rounded-full bg-muted px-3 py-1 text-sm font-medium text-text",
+        "inline-flex items-center rounded-full bg-muted px-3 py-1 text-sm font-medium text-slate-700",
         className,
       )}
       {...props}

--- a/frontend/components/ui/button.tsx
+++ b/frontend/components/ui/button.tsx
@@ -6,17 +6,15 @@ import type { ButtonHTMLAttributes } from "react";
 
 import { cn } from "../../lib/utils";
 
-type ButtonVariant = "primary" | "secondary" | "ghost";
+type ButtonVariant = "primary" | "secondary";
 type ButtonSize = "md" | "lg";
 
 const baseClasses =
-  "inline-flex items-center justify-center rounded-lg font-medium transition-colors ring-focus disabled:pointer-events-none disabled:opacity-60";
+  "inline-flex items-center justify-center rounded-lg font-medium transition-colors focus-visible:outline-none disabled:pointer-events-none disabled:opacity-60";
 
 const variantClasses: Record<ButtonVariant, string> = {
   primary: "bg-primary text-primary-foreground hover:bg-primary/90",
-  secondary:
-    "border border-border bg-white text-text hover:bg-muted",
-  ghost: "text-slate-600 hover:bg-muted",
+  secondary: "border border-border bg-white text-text hover:bg-muted",
 };
 
 const sizeClasses: Record<ButtonSize, string> = {

--- a/frontend/components/ui/card.tsx
+++ b/frontend/components/ui/card.tsx
@@ -6,7 +6,7 @@ export function Card({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
   return (
     <div
       className={cn(
-        "rounded-2xl border border-border bg-card p-6 shadow-sm transition-shadow hover:shadow-md",
+        "rounded-2xl border border-border bg-card p-6 shadow-sm",
         className,
       )}
       {...props}

--- a/frontend/components/ui/navbar.tsx
+++ b/frontend/components/ui/navbar.tsx
@@ -21,7 +21,7 @@ export function Navbar() {
         <div className="flex items-center gap-8">
           <Link
             href="/"
-            className="text-lg font-semibold text-text ring-focus"
+            className="text-lg font-semibold text-text focus-visible:outline-none"
             aria-label="PubLégalFR"
           >
             PubLégalFR
@@ -38,11 +38,12 @@ export function Navbar() {
                   key={link.href}
                   href={link.href}
                   className={cn(
-                    "transition-colors ring-focus",
+                    "transition-colors focus-visible:outline-none",
                     isActive
                       ? "text-primary underline decoration-2 underline-offset-8"
                       : "hover:text-primary",
                   )}
+                  aria-current={isActive ? "page" : undefined}
                 >
                   {link.label}
                 </Link>
@@ -53,7 +54,7 @@ export function Navbar() {
         <div className="flex items-center gap-3">
           <Link
             href="/api/auth/signin"
-            className="text-sm font-medium text-slate-600 transition-colors ring-focus hover:text-primary"
+            className="text-sm font-medium text-slate-600 transition-colors focus-visible:outline-none hover:text-primary"
           >
             Connexion
           </Link>


### PR DESCRIPTION
## Summary
- update the global utilities to add the new focus and shadow styling
- refresh shared UI components (navbar, button, badge, card) to align with the minimal design system
- redesign the home page hero, feature cards, and social proof section to match the requested layout

## Testing
- npm run lint *(fails: Next.js tries to install TypeScript via yarn and the registry is blocked in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6969104f08329b83b03ba8b2b858d