### PR TITLE
Refine hero layout with responsive grid visuals

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -78,6 +78,136 @@
   }
 }
 
+@layer components {
+  .hero-badge {
+    @apply relative inline-flex items-center gap-2 rounded-full px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-primary;
+    background: rgba(79, 70, 229, 0.12);
+  }
+
+  .hero-badge::before {
+    content: "";
+    width: 0.4rem;
+    height: 0.4rem;
+    border-radius: 999px;
+    background: linear-gradient(135deg, #1f3ae0, #38bdf8);
+    box-shadow: 0 0 0 4px rgba(79, 70, 229, 0.15);
+  }
+
+  .hero-highlights {
+    @apply grid gap-3 text-sm text-slate-700;
+  }
+
+  .hero-highlight {
+    @apply relative flex items-center gap-3 rounded-2xl border border-primary/10 bg-primary/5 px-4 py-3 font-medium backdrop-blur;
+  }
+
+  .hero-highlight::before {
+    content: "";
+    width: 0.55rem;
+    height: 0.55rem;
+    border-radius: 999px;
+    background: linear-gradient(135deg, #1f3ae0, #38bdf8);
+    box-shadow: 0 0 0 6px rgba(31, 58, 224, 0.14);
+  }
+
+  .hero-stats {
+    @apply grid gap-4 sm:grid-cols-3;
+  }
+
+  .hero-stats div {
+    @apply rounded-3xl border border-slate-200/60 bg-white/80 p-6 text-left shadow-[0_20px_45px_rgba(15,23,42,0.1)];
+  }
+
+  .hero-stats dt {
+    @apply text-3xl font-semibold text-primary;
+  }
+
+  .hero-stats dd {
+    @apply mt-2 text-sm text-slate-600;
+  }
+
+  .hero-visual {
+    @apply grid gap-6;
+  }
+
+  .hero-card {
+    @apply flex flex-col gap-4 rounded-3xl border border-white/10 bg-slate-900/80 p-8 text-slate-100 shadow-[0_25px_60px_rgba(15,23,42,0.25)];
+    backdrop-filter: blur(12px);
+  }
+
+  .hero-card--primary {
+    background: linear-gradient(160deg, rgba(79, 70, 229, 0.92), rgba(30, 64, 175, 0.85));
+  }
+
+  .hero-card--secondary {
+    background: rgba(15, 23, 42, 0.82);
+  }
+
+  .hero-card__label {
+    @apply text-xs font-semibold uppercase tracking-[0.2em] text-slate-200/80;
+  }
+
+  .hero-card__value {
+    @apply text-4xl font-semibold tracking-tight text-slate-50;
+  }
+
+  .hero-card__hint {
+    @apply text-sm text-slate-200/80;
+  }
+
+  .hero-card__tags {
+    @apply flex flex-wrap gap-2 text-xs font-semibold;
+  }
+
+  .hero-card__tags li {
+    @apply rounded-full border border-white/20 bg-white/10 px-3 py-1;
+  }
+
+  .hero-card__progress {
+    @apply flex flex-col gap-3;
+  }
+
+  .hero-card__progress-label {
+    @apply text-xs font-semibold uppercase tracking-[0.2em] text-slate-200/75;
+  }
+
+  .hero-progress {
+    @apply flex items-center gap-3;
+  }
+
+  .hero-progress__value {
+    @apply text-lg font-semibold text-slate-50;
+  }
+
+  .hero-progress__track {
+    @apply h-2 flex-1 overflow-hidden rounded-full bg-slate-200/20;
+  }
+
+  .hero-progress__fill {
+    display: block;
+    height: 100%;
+    border-radius: 999px;
+    background: linear-gradient(135deg, #38bdf8, #1f3ae0);
+  }
+
+  .hero-card__team {
+    @apply mt-2 flex items-center gap-4 border-t border-white/10 pt-4 text-sm text-slate-200/75;
+  }
+
+  .hero-avatar-stack {
+    @apply flex items-center;
+  }
+
+  .hero-avatar {
+    @apply grid h-10 w-10 place-items-center rounded-full border border-white/40 bg-white/10 text-sm font-semibold tracking-[0.05em];
+    margin-left: -0.75rem;
+  }
+
+  .hero-avatar:first-child {
+    margin-left: 0;
+  }
+}
+
 :where(button, a).[class*="focus-visible"] {
   @apply ring-2 ring-primary ring-offset-2;
 }

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,6 +1,15 @@
-import { Badge } from "../components/ui/badge";
 import { Button } from "../components/ui/button";
 import { Card } from "../components/ui/card";
+
+const heroHighlights = [
+  "Feuille de route data-driven priorisée",
+  "Benchmark sectoriel & projections chiffrées",
+  "Activation accompagnée par une équipe senior",
+];
+
+const heroTags = ["Acquisition", "CRO", "CRM"];
+
+const heroTeam = ["AB", "LM", "SG"];
 
 const metrics = [
   { value: "+37%", label: "de ROI moyen après 90 jours" },
@@ -138,40 +147,76 @@ export default function Home() {
     <div className="space-y-24 pb-24">
       <section className="relative overflow-hidden">
         <div className="pointer-events-none absolute inset-0 bg-hero-radial" aria-hidden="true" />
-        <div className="container relative flex flex-col items-center gap-16 py-24 text-center">
-          <div className="flex max-w-4xl flex-col items-center gap-6">
-            <Badge className="bg-primary/10 text-primary">Audit marketing premium</Badge>
-            <h1 className="text-4xl font-semibold tracking-tight text-text sm:text-5xl">
-              Identifiez vos leviers de croissance en moins de 7 jours
-            </h1>
-            <p className="max-w-3xl text-lg text-slate-600">
-              Nos experts data, acquisition et CRM analysent l'intégralité de votre expérience client pour révéler les actions
-              à plus fort impact. Vous repartez avec une feuille de route priorisée, prête à activer par vos équipes.
-            </p>
-            <div className="flex w-full flex-col gap-4 sm:w-auto sm:flex-row sm:justify-center">
+        <div className="container relative grid gap-12 py-24 text-center lg:grid-cols-[minmax(0,1.05fr)_minmax(0,0.95fr)] lg:items-center lg:text-left">
+          <div className="flex flex-col gap-6">
+            <span className="hero-badge self-center lg:self-start">Audit marketing premium</span>
+            <div className="flex flex-col gap-4">
+              <h1 className="text-4xl font-semibold tracking-tight text-text sm:text-5xl">
+                Identifiez vos leviers de croissance en moins de 7 jours
+              </h1>
+              <p className="mx-auto max-w-2xl text-lg text-slate-600 lg:mx-0">
+                Nos experts data, acquisition et CRM analysent l'intégralité de votre expérience client pour révéler les
+                actions à plus fort impact. Vous repartez avec une feuille de route priorisée, prête à activer par vos
+                équipes.
+              </p>
+            </div>
+            <ul className="hero-highlights mx-auto max-w-2xl lg:mx-0">
+              {heroHighlights.map((highlight) => (
+                <li key={highlight} className="hero-highlight">
+                  {highlight}
+                </li>
+              ))}
+            </ul>
+            <div className="flex flex-col gap-4 sm:flex-row sm:justify-center lg:justify-start">
               <Button href="/analyser" size="lg" className="w-full sm:w-auto">
                 Demander un audit personnalisé
               </Button>
-              <Button
-                href="/historique"
-                size="lg"
-                variant="secondary"
-                className="w-full sm:w-auto"
-              >
+              <Button href="/historique" size="lg" variant="secondary" className="w-full sm:w-auto">
                 Découvrir un rapport type
               </Button>
             </div>
+            <dl className="hero-stats mx-auto lg:mx-0" aria-label="Chiffres clés de nos accompagnements">
+              {metrics.map((metric) => (
+                <div key={metric.label}>
+                  <dt>{metric.value}</dt>
+                  <dd>{metric.label}</dd>
+                </div>
+              ))}
+            </dl>
           </div>
 
-          <div className="grid w-full gap-6 sm:grid-cols-3">
-            {metrics.map((metric) => (
-              <Card key={metric.label} className="bg-white/80 text-left">
-                <div className="flex flex-col gap-2">
-                  <span className="text-3xl font-semibold text-primary">{metric.value}</span>
-                  <p className="text-sm text-slate-600">{metric.label}</p>
+          <div className="hero-visual" aria-hidden="true">
+            <div className="hero-card hero-card--primary">
+              <span className="hero-card__label">Projection de croissance</span>
+              <p className="hero-card__value">+128%</p>
+              <p className="hero-card__hint">Pipeline qualifié sur 6 mois</p>
+              <ul className="hero-card__tags">
+                {heroTags.map((tag) => (
+                  <li key={tag}>{tag}</li>
+                ))}
+              </ul>
+            </div>
+            <div className="hero-card hero-card--secondary">
+              <div className="hero-card__progress">
+                <span className="hero-card__progress-label">Score d'opportunités</span>
+                <div className="hero-progress" role="presentation">
+                  <span className="hero-progress__value">82%</span>
+                  <div className="hero-progress__track">
+                    <span className="hero-progress__fill" style={{ width: "82%" }} />
+                  </div>
                 </div>
-              </Card>
-            ))}
+              </div>
+              <div className="hero-card__team">
+                <div className="hero-avatar-stack" aria-hidden="true">
+                  {heroTeam.map((initials) => (
+                    <span key={initials} className="hero-avatar">
+                      {initials}
+                    </span>
+                  ))}
+                </div>
+                <p>Équipe senior dédiée à votre compte</p>
+              </div>
+            </div>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- replace the hero section with a two-column layout that mirrors the original marketing page structure
- restore key content including highlights list, stat blocks, and dual visual cards with projection/progress details
- add Tailwind-based component classes to reproduce bespoke badges, tags, progress meter, and avatar stack styling

## Testing
- `npm run lint` *(fails: Next.js attempts to install TypeScript via Yarn and aborts because the repository is not configured as a Yarn workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68d6e8c86dc48329a9ea547767564c7a