### PR TITLE
Add badge component import on homepage

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,5 +1,6 @@
 import { Button } from "../components/ui/button";
 import { Card } from "../components/ui/card";
+import { Badge } from "../components/ui/badge";
 
 const heroHighlights = [
   "Feuille de route data-driven priorisée",


### PR DESCRIPTION
## Summary
- add the Badge component import to the homepage page module to match existing usage

## Testing
- npm run build *(fails: dependency installation requires yarn workspace configuration and TypeScript setup in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6f90913e88329b08e83a0ac46a09c