### PR TITLE
Fix focus-visible selector syntax

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -222,6 +222,6 @@
   }
 }
 
-:where(button, a).[class*="focus-visible"] {
+:where(button, a)[class*="focus-visible"] {
   @apply ring-2 ring-primary ring-offset-2;
 }


### PR DESCRIPTION
## Summary
- correct the focus-visible selector in globals.css to ensure the accessibility ring applies to buttons and links

## Testing
- npm run build *(fails: missing dependencies due to blocked npm registry access when installing @prisma/client)*

------
https://chatgpt.com/codex/tasks/task_e_68d6f91a9ac88329a44b367810498800