### PR TITLE
Ajoute l’ancre de navigation sur la section preuves

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -440,7 +440,7 @@ export default function Home() {
         </div>
       </section>
 
-      <section className="container space-y-12">
+      <section id="preuves" className="container space-y-12">
         <div className="flex flex-col gap-4 text-center">
           <Badge className="self-center bg-primary/10 text-primary">Résultats</Badge>
           <h2 className="text-3xl font-semibold text-text">Des résultats mesurables dès les premières semaines</h2>


### PR DESCRIPTION
## Summary
- ajoute l’attribut id="preuves" sur la section Résultats pour aligner l’ancre avec le lien de navigation

## Testing
- npm run dev *(fails: Next.js tente d’installer TypeScript via Yarn mais échoue car le dossier parent contient un package.json distinct)*

------
https://chatgpt.com/codex/tasks/task_e_68d6f926c7848329932d8fac498be5da