### PR TITLE
Refactor cookie banner to tailwind modal

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 
 import { cn } from "../lib/utils";
 import { Navbar } from "../components/ui/navbar";
+import { CookieBanner } from "../components/compliance/CookieBanner";
 import { Button } from "../components/ui/button";
 import "./globals.css";
 
@@ -24,6 +25,7 @@ export default function RootLayout({
       <body className={cn(inter.className, "min-h-screen bg-section-fade text-text antialiased")}>
         <div className="flex min-h-screen flex-col">
           <Navbar />
+          <CookieBanner />
           <main className="flex-1">{children}</main>
           <Footer />
         </div>


### PR DESCRIPTION
## Summary
- move the cookie banner into `frontend/components/compliance` and restyle it with Tailwind tokens and shared buttons
- add an event-driven hook to open the banner and mount it from the root layout

## Testing
- npm run lint *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68d6fbf9a94c83299b84a56e9bb90949