### PR TITLE
Refactor historique page into case studies showcase

### DIFF
--- a/frontend/app/historique/page.tsx
+++ b/frontend/app/historique/page.tsx
@@ -1,44 +1,86 @@
 import { Badge } from "../../components/ui/badge";
+import { Button } from "../../components/ui/button";
+import { Card } from "../../components/ui/card";
+import { caseStudies } from "../../data/case-studies";
 
-const tableHeaders = ["Date", "URL analysée", "Score global"];
+const clientLogos = ["Alan", "Back Market", "Qonto", "Mirakl", "Swile"];
 
-export default function HistoriquePage() {
+export default function CaseStudiesPage() {
   return (
     <div className="container py-12 sm:py-16">
       <div className="mx-auto max-w-3xl text-center">
-        <Badge className="mb-6 bg-primary/10 text-primary">Historique</Badge>
+        <Badge className="mb-6 bg-primary/10 text-primary">Cas clients</Badge>
         <h1 className="text-4xl font-semibold tracking-tight text-text sm:text-5xl">
-          Vos analyses récentes
+          Nos cas clients
         </h1>
         <p className="mt-4 text-lg text-slate-600">
-          Retrouvez ici l’ensemble de vos audits. Exportez chaque rapport ou relancez un contrôle en un clic dès qu’une mise à jour est nécessaire.
+          Des scale-up aux ETI, nous accompagnons les équipes marketing et growth qui veulent des résultats mesurables. Voici des missions récentes qui illustrent notre méthodologie basée sur les preuves et l'impact business.
         </p>
       </div>
 
-      <div className="mt-10 overflow-hidden rounded-2xl border border-border bg-white shadow-sm">
-        <table className="min-w-full divide-y divide-border/70">
-          <thead className="bg-muted/60">
-            <tr>
-              {tableHeaders.map((header) => (
-                <th
-                  key={header}
-                  scope="col"
-                  className="px-6 py-4 text-left text-sm font-semibold uppercase tracking-wider text-slate-500"
-                >
-                  {header}
-                </th>
-              ))}
-            </tr>
-          </thead>
-          <tbody className="divide-y divide-border/60">
-            <tr>
-              <td colSpan={3} className="px-6 py-12 text-center text-sm text-slate-500">
-                Votre historique apparaîtra ici dès qu’une première analyse aura été réalisée.
-              </td>
-            </tr>
-          </tbody>
-        </table>
+      <div className="mt-12 grid gap-6 sm:grid-cols-2 xl:mt-16 xl:grid-cols-3">
+        {caseStudies.map((study) => (
+          <Card
+            key={study.name}
+            className="flex h-full flex-col gap-6 rounded-3xl border-slate-200/70 bg-white p-8 shadow-lg"
+          >
+            <header className="flex items-start justify-between gap-4">
+              <span className="inline-flex items-center rounded-full bg-primary/10 px-4 py-1 text-sm font-semibold text-primary">
+                {study.logo}
+              </span>
+              <span className="text-sm font-medium uppercase tracking-[0.2em] text-slate-400">
+                {study.sector}
+              </span>
+            </header>
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">Résultat clé</p>
+              <p className="text-2xl font-semibold text-primary sm:text-3xl">{study.kpi}</p>
+            </div>
+            <div className="space-y-2">
+              <p className="text-sm font-semibold text-slate-500">{study.name}</p>
+              <blockquote className="text-sm leading-relaxed text-slate-600">
+                “{study.testimonial}”
+              </blockquote>
+            </div>
+          </Card>
+        ))}
       </div>
+
+      <section className="mt-16 rounded-3xl border border-slate-200/70 bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-10 text-slate-50 shadow-xl sm:p-14">
+        <div className="grid gap-10 lg:grid-cols-[2fr,1fr] lg:items-center">
+          <div className="space-y-6">
+            <div>
+              <span className="inline-flex items-center rounded-full bg-white/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-primary-foreground/80">
+                Prêts à tester ?
+              </span>
+              <h2 className="mt-3 text-3xl font-semibold tracking-tight sm:text-4xl">
+                Analysez votre funnel et obtenez votre plan d'actions priorisé
+              </h2>
+            </div>
+            <p className="text-base text-slate-200">
+              Nos experts réalisent un diagnostic express de vos parcours, livrent vos quick wins et vous accompagnent sur l'exécution.
+            </p>
+            <Button href="/analyser" size="lg" className="w-full sm:w-auto">
+              Lancer mon analyse
+            </Button>
+          </div>
+          <div className="space-y-6">
+            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400/80">
+              Ils nous font confiance
+            </p>
+            <div className="grid grid-cols-2 gap-4 text-center text-sm font-medium text-slate-200 sm:grid-cols-3">
+              {clientLogos.map((logo) => (
+                <span
+                  key={logo}
+                  className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 backdrop-blur"
+                >
+                  {logo}
+                </span>
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
     </div>
   );
 }

--- a/frontend/data/case-studies.ts
+++ b/frontend/data/case-studies.ts
@@ -1,0 +1,42 @@
+export interface CaseStudy {
+  name: string;
+  logo: string;
+  sector: string;
+  kpi: string;
+  testimonial: string;
+}
+
+export const caseStudies: CaseStudy[] = [
+  {
+    name: "Fintech Qonto",
+    logo: "Qonto",
+    sector: "Services financiers",
+    kpi: "+42% de leads SQL en 90 jours",
+    testimonial:
+      "L'équipe a cadré des scénarios multicanaux qui ont enfin aligné marketing et sales sur nos comptes stratégiques.",
+  },
+  {
+    name: "Retail éthique Loom",
+    logo: "Loom",
+    sector: "E-commerce",
+    kpi: "-28% de coût d'acquisition",
+    testimonial:
+      "En six semaines, nous avons retrouvé un ROAS rentable et un pilotage clair pour réinvestir dans nos meilleures audiences.",
+  },
+  {
+    name: "SaaS RH Alan",
+    logo: "Alan",
+    sector: "Scale-up",
+    kpi: "+3 pts de taux de conversion trial",
+    testimonial:
+      "Leur lecture des parcours d'activation nous a permis de prioriser les quick wins CRM et d'accélérer notre expansion européenne.",
+  },
+  {
+    name: "Industrie durable Ecov",
+    logo: "Ecov",
+    sector: "Mobilité",
+    kpi: "+58% d'utilisation des lignes",
+    testimonial:
+      "La mission a structuré nos données et livré un plan d'actions concret qui a engagé les équipes terrain comme le COMEX.",
+  },
+];


### PR DESCRIPTION
## Summary
- rename the historique view into a case study hub with updated badge, title, introduction, and CTA
- replace the empty table with a responsive grid of social-proof case study cards backed by a reusable data module
- add a closing CTA block that mirrors the homepage with a trust logo carousel and link to launch a new analysis

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6fbfbdce4832995bc1bc331ea7005