### PR TITLE
Refactor landing page to mirror reference design

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,35 +1,11 @@
 import { Button } from "../components/ui/button";
 import { Card } from "../components/ui/card";
-import { Badge } from "../components/ui/badge";
 
-const heroHighlights = [
-  "Feuille de route data-driven priorisée",
-  "Benchmark sectoriel & projections chiffrées",
-  "Activation accompagnée par une équipe senior",
-];
-
-const heroTags = ["Acquisition", "CRO", "CRM"];
-
-const heroTeam = ["AB", "LM", "SG"];
-
-const metrics = [
-  { value: "+37%", label: "de ROI moyen après 90 jours" },
-  { value: "92%", label: "de clients renouvellent la mission" },
-  { value: "4,9/5", label: "de satisfaction équipe et direction" },
-];
-
-const trustLogos = ["Alan", "BackMarket", "Qonto", "Mirakl", "Swile"];
-
-const services = [
+const features = [
   {
-    title: "Campagnes d'acquisition",
+    title: "Score global",
     description:
-      "Audit de vos comptes ads, ciblages, créations et landing pages pour révéler les leviers de croissance rapides.",
-    bullets: [
-      "Analyse des plateformes payantes et mix média",
-      "Refonte des audiences & segments prioritaires",
-      "Optimisation des messages et visuels clés",
-    ],
+      "Obtenez un score de conformité instantané et des recommandations classées par priorité.",
     icon: (
       <svg
         className="h-10 w-10 text-primary"
@@ -41,21 +17,15 @@ const services = [
         strokeLinejoin="round"
         aria-hidden="true"
       >
-        <path d="M4 6h24v4H4z" />
-        <path d="M4 14h16v4H4z" />
-        <path d="M4 22h24v4H4z" />
+        <circle cx="16" cy="16" r="12" />
+        <path d="M16 8v8l5 5" />
       </svg>
     ),
   },
   {
-    title: "Parcours & conversion",
+    title: "Export PDF",
     description:
-      "Étude comportementale de vos tunnels, UX research et scoring des quick wins pour améliorer chaque étape.",
-    bullets: [
-      "Heatmaps, analytics & lecture des funnels",
-      "CRO des landing pages et pages produit",
-      "Backlog d'expérimentations priorisé",
-    ],
+      "Générez un rapport détaillé conforme aux attentes des équipes juridiques et compliance.",
     icon: (
       <svg
         className="h-10 w-10 text-primary"
@@ -67,21 +37,17 @@ const services = [
         strokeLinejoin="round"
         aria-hidden="true"
       >
-        <path d="M4 8l12 8 12-8-12-6z" />
-        <path d="M4 12v12l12 6V18z" />
-        <path d="M28 12v12l-12 6V18z" />
+        <path d="M8 4h12l8 8v16H8z" />
+        <path d="M20 4v8h8" />
+        <path d="M12 20h8" />
+        <path d="M12 24h12" />
       </svg>
     ),
   },
   {
-    title: "CRM & fidélisation",
+    title: "Historique",
     description:
-      "Cartographiez vos scénarios, segmentez vos bases et automatisez les messages à forte valeur pour chaque persona.",
-    bullets: [
-      "Diagnostic des scénarios transactionnels & relationnels",
-      "Scoring clients, RFM et segments dynamiques",
-      "Playbooks d'automations & contenus personnalisés",
-    ],
+      "Suivez l'évolution de vos analyses et conservez un registre conforme pour chaque campagne.",
     icon: (
       <svg
         className="h-10 w-10 text-primary"
@@ -93,384 +59,88 @@ const services = [
         strokeLinejoin="round"
         aria-hidden="true"
       >
-        <path d="M6 6h20v20H6z" />
-        <path d="M16 12v8" />
-        <path d="M12 16h8" />
+        <path d="M6 12a10 10 0 1110 10" />
+        <path d="M16 8v6l4 2" />
+        <path d="M6 16l-4-4 4-4" />
       </svg>
     ),
   },
 ];
 
-const methodology = [
-  {
-    step: "01",
-    title: "Kick-off & cadrage",
-    subtitle: "Objectifs business & organisation",
-    description:
-      "Immersion dans votre contexte, récupération des accès et cadrage des KPI pour aligner toutes les parties prenantes.",
-    deliverable: "Checklist des accès + feuille de route d'audit",
-  },
-  {
-    step: "02",
-    title: "Analyse 360°",
-    subtitle: "Data, acquisition, CRM & conformité",
-    description:
-      "Audit croisé de vos comptes ads, analytics, CRM et assets créatifs avec scoring des opportunités par impact business.",
-    deliverable: "Tableau de bord interactif + benchmark sectoriel",
-  },
-  {
-    step: "03",
-    title: "Restitution & activation",
-    subtitle: "Priorisation & accompagnement",
-    description:
-      "Atelier de restitution auprès de vos équipes, co-construction du plan d'actions et accompagnement sur la mise en œuvre.",
-    deliverable: "Roadmap priorisée sur 90 jours + coaching des équipes",
-  },
+const supportPoints = [
+  "Un service pensé pour les équipes marketing, juridique et compliance.",
+  "Disponible pour les TPE, PME et agences.",
 ];
 
-const insights = [
-  {
-    eyebrow: "Acquisition",
-    value: "+64%",
-    description: "Augmentation moyenne du volume de leads qualifiés dès le premier trimestre.",
-    bullets: [
-      "Restructuration media buying multi-plateformes",
-      "Création d'actifs créatifs testables en continu",
-    ],
-  },
-  {
-    eyebrow: "Conversion",
-    value: "-32%",
-    description: "Réduction constatée du coût d'acquisition client sur les parcours clés.",
-    bullets: [
-      "Expérimentations CRO priorisées par potentiel",
-      "Optimisation du copywriting et des offres",
-    ],
-  },
-  {
-    eyebrow: "Fidélisation",
-    value: "+48 pts",
-    description: "Gain moyen de Customer Lifetime Value pour les comptes accompagnés.",
-    bullets: [
-      "Personnalisation des scénarios CRM & marketing automation",
-      "Reporting prédictif sur mesure",
-    ],
-  },
-];
-
-const ctaBullets = [
-  "Diagnostic gratuit de vos enjeux actuels",
-  "Projection de gains personnalisée",
-  "Accès à un plan d'action priorisé",
-];
-
-interface InsightCardProps {
-  eyebrow: string;
-  value: string;
-  description: string;
-  bullets: string[];
-}
-
-function InsightCard({ eyebrow, value, description, bullets }: InsightCardProps) {
+function ArrowRightIcon() {
   return (
-    <Card className="h-full gap-4 rounded-2xl border-slate-200/60 bg-white/95 p-8 text-left shadow-lg backdrop-blur transition-all duration-300 hover:-translate-y-1 hover:shadow-elevated">
-      <header className="flex items-baseline justify-between gap-4">
-        <span className="inline-flex items-center rounded-full bg-primary/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-primary">
-          {eyebrow}
-        </span>
-        <strong className="text-3xl font-semibold text-primary">{value}</strong>
-      </header>
-      <p className="text-sm text-slate-600">{description}</p>
-      <ul className="space-y-2 text-sm text-slate-600">
-        {bullets.map((bullet) => (
-          <li key={bullet} className="flex items-start gap-2">
-            <span className="mt-1 inline-flex h-1.5 w-1.5 flex-none rounded-full bg-primary" aria-hidden="true" />
-            <span>{bullet}</span>
-          </li>
-        ))}
-      </ul>
-    </Card>
+    <svg className="ml-2 h-4 w-4" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden="true">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M5 10h10" />
+      <path strokeLinecap="round" strokeLinejoin="round" d="M11 6l4 4-4 4" />
+    </svg>
   );
 }
 
-function EnablementHighlight() {
+function DocumentIcon() {
   return (
-    <div className="grid gap-6 rounded-[28px] border border-white/30 bg-gradient-to-tr from-indigo-500/95 via-indigo-600/95 to-indigo-700/95 px-10 py-12 text-slate-100 shadow-[0_32px_70px_rgba(79,70,229,0.25)]">
-      <div className="space-y-4">
-        <span className="inline-flex items-center gap-2 rounded-full bg-slate-900/30 px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em]">
-          <span className="inline-block h-1.5 w-1.5 rounded-full bg-accent" aria-hidden="true" />
-          Enablement
-        </span>
-        <h2 className="text-3xl font-semibold leading-tight text-white md:text-[2.4rem]">
-          Un accompagnement pensé pour vos équipes
-        </h2>
-        <p className="max-w-2xl text-base text-slate-200/85">
-          Des livrables synthétiques, des recommandations priorisées et des ateliers opérationnels pour accélérer votre passage à l'action.
-        </p>
-      </div>
-      <ul className="space-y-3 text-sm text-slate-100/90">
-        <li>Tableaux de bord prêts à l'emploi</li>
-        <li>Templates de campagnes &amp; automations</li>
-        <li>Suivi mensuel sur mesure</li>
-      </ul>
-    </div>
-  );
-}
-
-function ContactPanel() {
-  return (
-    <div className="grid gap-6 rounded-[28px] border border-slate-800/60 bg-slate-900/80 p-8 shadow-[0_32px_70px_rgba(15,23,42,0.35)] backdrop-blur md:p-10 lg:grid-cols-[1fr_minmax(0,1.05fr)]">
-      <div className="flex flex-col gap-5 rounded-2xl border border-white/10 bg-white/5 p-6 text-slate-100 md:p-7">
-        <p className="text-sm text-slate-100/90">
-          Écrivez-nous à <a href="mailto:contact@audit-marketing.fr" className="font-semibold text-white underline">contact@audit-marketing.fr</a> ou choisissez un créneau dans notre agenda partagé. Nous revenons vers vous sous 24h ouvrées.
-        </p>
-        <ul className="space-y-2 text-sm text-slate-100/85">
-          {ctaBullets.map((bullet) => (
-            <li key={bullet} className="flex items-start gap-2">
-              <span className="mt-1 inline-flex h-1.5 w-1.5 flex-none rounded-full bg-accent" aria-hidden="true" />
-              <span>{bullet}</span>
-            </li>
-          ))}
-        </ul>
-      </div>
-      <form
-        className="flex flex-col gap-6 rounded-2xl border border-white/10 bg-white/5 p-6 text-left md:p-7"
-        action="https://formspree.io/f/mwkjakdl"
-        method="post"
-      >
-        <div className="grid gap-4 md:grid-cols-2">
-          <label className="cta-field">
-            Nom et prénom
-            <input className="cta-input" type="text" name="name" autoComplete="name" required />
-          </label>
-          <label className="cta-field">
-            Email professionnel
-            <input className="cta-input" type="email" name="email" autoComplete="email" required />
-          </label>
-          <label className="cta-field">
-            Entreprise
-            <input className="cta-input" type="text" name="company" autoComplete="organization" />
-          </label>
-          <label className="cta-field">
-            Objectif principal
-            <select className="cta-input" name="goal" required defaultValue="">
-              <option value="" disabled>
-                Choisissez un objectif
-              </option>
-              <option value="acquisition">Accélérer l'acquisition</option>
-              <option value="conversion">Optimiser la conversion</option>
-              <option value="fidelisation">Renforcer la fidélisation</option>
-              <option value="data">Structurer la data</option>
-            </select>
-          </label>
-        </div>
-        <label className="cta-field">
-          Décrivez vos enjeux
-          <textarea
-            className="cta-input min-h-[9.5rem]"
-            name="context"
-            rows={4}
-            placeholder="Parlez-nous de vos objectifs et des défis actuels"
-          />
-        </label>
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-          <Button type="submit" size="lg" className="w-full shadow-[0_24px_45px_rgba(15,23,42,0.3)] sm:w-auto">
-            Réserver un créneau
-          </Button>
-          <p className="cta-note">Aucun engagement. Nous revenons vers vous sous 24h ouvrées.</p>
-        </div>
-      </form>
-    </div>
+    <svg className="ml-2 h-4 w-4" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden="true">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M7 2h6l4 4v12H7z" />
+      <path strokeLinecap="round" strokeLinejoin="round" d="M13 2v4h4" />
+    </svg>
   );
 }
 
 export default function Home() {
   return (
-    <div className="space-y-24 pb-24">
-      <section className="relative overflow-hidden">
-        <div className="pointer-events-none absolute inset-0 bg-hero-radial" aria-hidden="true" />
-        <div className="container relative grid gap-12 py-24 text-center lg:grid-cols-[minmax(0,1.05fr)_minmax(0,0.95fr)] lg:items-center lg:text-left">
-          <div className="flex flex-col gap-6">
-            <span className="hero-badge self-center lg:self-start">Audit marketing premium</span>
-            <div className="flex flex-col gap-4">
-              <h1 className="text-4xl font-semibold tracking-tight text-text sm:text-5xl">
-                Identifiez vos leviers de croissance en moins de 7 jours
-              </h1>
-              <p className="mx-auto max-w-2xl text-lg text-slate-600 lg:mx-0">
-                Nos experts data, acquisition et CRM analysent l'intégralité de votre expérience client pour révéler les
-                actions à plus fort impact. Vous repartez avec une feuille de route priorisée, prête à activer par vos
-                équipes.
-              </p>
-            </div>
-            <ul className="hero-highlights mx-auto max-w-2xl lg:mx-0">
-              {heroHighlights.map((highlight) => (
-                <li key={highlight} className="hero-highlight">
-                  {highlight}
-                </li>
-              ))}
-            </ul>
-            <div className="flex flex-col gap-4 sm:flex-row sm:justify-center lg:justify-start">
-              <Button href="/analyser" size="lg" className="w-full sm:w-auto">
-                Demander un audit personnalisé
-              </Button>
-              <Button href="/historique" size="lg" variant="secondary" className="w-full sm:w-auto">
-                Découvrir un rapport type
-              </Button>
-            </div>
-            <dl className="hero-stats mx-auto lg:mx-0" aria-label="Chiffres clés de nos accompagnements">
-              {metrics.map((metric) => (
-                <div key={metric.label}>
-                  <dt>{metric.value}</dt>
-                  <dd>{metric.label}</dd>
-                </div>
-              ))}
-            </dl>
-          </div>
-
-          <div className="hero-visual" aria-hidden="true">
-            <div className="hero-card hero-card--primary">
-              <span className="hero-card__label">Projection de croissance</span>
-              <p className="hero-card__value">+128%</p>
-              <p className="hero-card__hint">Pipeline qualifié sur 6 mois</p>
-              <ul className="hero-card__tags">
-                {heroTags.map((tag) => (
-                  <li key={tag}>{tag}</li>
-                ))}
-              </ul>
-            </div>
-            <div className="hero-card hero-card--secondary">
-              <div className="hero-card__progress">
-                <span className="hero-card__progress-label">Score d'opportunités</span>
-                <div className="hero-progress" role="presentation">
-                  <span className="hero-progress__value">82%</span>
-                  <div className="hero-progress__track">
-                    <span className="hero-progress__fill" style={{ width: "82%" }} />
-                  </div>
-                </div>
-              </div>
-              <div className="hero-card__team">
-                <div className="hero-avatar-stack" aria-hidden="true">
-                  {heroTeam.map((initials) => (
-                    <span key={initials} className="hero-avatar">
-                      {initials}
-                    </span>
-                  ))}
-                </div>
-                <p>Équipe senior dédiée à votre compte</p>
-              </div>
-            </div>
-          </div>
+    <div className="bg-white">
+      <section className="container flex flex-col items-center gap-12 py-24 text-center sm:py-28">
+        <div className="inline-flex items-center gap-3 rounded-full border border-border/70 bg-white px-5 py-2 text-xs font-semibold uppercase tracking-[0.28em] text-slate-600 shadow-sm">
+          <span className="relative inline-flex h-6 w-12 items-center rounded-full bg-slate-100 p-1">
+            <span className="inline-flex h-4 w-4 rounded-full bg-primary shadow-[0_8px_15px_rgba(31,58,224,0.35)]" />
+          </span>
+          Conformité publicitaire instantanée
         </div>
-      </section>
 
-      <section className="container" aria-label="Références clients">
-        <div className="flex flex-col gap-6 rounded-3xl border border-border/70 bg-white/90 px-8 py-10 shadow-sm backdrop-blur">
-          <div className="flex flex-col items-center gap-2 text-center">
-            <span className="text-xs font-semibold uppercase tracking-[0.3em] text-primary/70">
-              Ils nous font confiance
-            </span>
-            <p className="text-sm text-slate-500">+120 projets accompagnés sur les 24 derniers mois</p>
-          </div>
-          <div className="flex flex-wrap items-center justify-center gap-8 text-lg font-medium text-slate-600">
-            {trustLogos.map((logo) => (
-              <span key={logo} className="text-slate-500">
-                {logo}
-              </span>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      <section id="services" className="container space-y-12">
-        <div className="flex flex-col gap-4 text-center">
-          <Badge className="self-center bg-accent/15 text-primary">Expertises</Badge>
-          <h2 className="text-3xl font-semibold text-text">Ce que nous analysons</h2>
-          <p className="mx-auto max-w-3xl text-base text-slate-600">
-            Une vision panoramique de vos performances marketing pour orchestrer des campagnes efficaces, rentables et
-            cohérentes sur l’ensemble du parcours client.
+        <div className="space-y-5 text-balance sm:space-y-6">
+          <h1 className="text-4xl font-semibold leading-tight text-text sm:text-5xl">
+            Analysez la conformité de vos publicités en 60 secondes
+          </h1>
+          <p className="mx-auto max-w-3xl text-lg text-slate-600">
+            Testez les refus de campagne Facebook, Google Ads et autres plateformes. Notre IA spécialisée vérifie la conformité
+            RGPD, mentions légales et réglementations françaises.
           </p>
         </div>
-        <div className="grid gap-8 md:grid-cols-3">
-          {services.map((service) => (
-            <Card key={service.title} className="flex h-full flex-col gap-6 text-left">
-              <span className="inline-flex h-14 w-14 items-center justify-center rounded-2xl bg-primary/10">
-                {service.icon}
-              </span>
-              <div className="flex flex-col gap-3">
-                <h3 className="text-xl font-semibold text-text">{service.title}</h3>
-                <p className="text-sm text-slate-600">{service.description}</p>
-              </div>
-              <ul className="mt-auto space-y-2 text-sm text-slate-600">
-                {service.bullets.map((bullet) => (
-                  <li key={bullet} className="flex items-start gap-2">
-                    <span className="mt-1 inline-flex h-2 w-2 rounded-full bg-primary" aria-hidden="true" />
-                    <span>{bullet}</span>
-                  </li>
-                ))}
-              </ul>
-            </Card>
+
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-center">
+          <Button href="/analyser" size="lg" className="w-full sm:w-auto">
+            Analyser une landing page
+            <ArrowRightIcon />
+          </Button>
+          <Button href="/historique" variant="secondary" size="lg" className="w-full sm:w-auto">
+            Voir un exemple de rapport
+            <DocumentIcon />
+          </Button>
+        </div>
+
+        <div className="space-y-2 text-sm font-medium text-slate-500">
+          {supportPoints.map((point) => (
+            <p key={point}>{point}</p>
           ))}
         </div>
-      </section>
 
-      <section id="methodologie" className="container space-y-12">
-        <div className="flex flex-col gap-4 text-center">
-          <Badge className="self-center bg-primary/10 text-primary">Méthodologie</Badge>
-          <h2 className="text-3xl font-semibold text-text">Un accompagnement senior de bout en bout</h2>
-          <p className="mx-auto max-w-3xl text-base text-slate-600">
-            De l’immersion initiale à l’activation, nous orchestrons chaque étape pour accélérer vos décisions et sécuriser la
-            conformité de vos campagnes.
-          </p>
-        </div>
-        <div className="grid gap-6 lg:grid-cols-3">
-          {methodology.map((step) => (
-            <Card key={step.step} className="flex h-full flex-col gap-5 text-left">
-              <span className="text-sm font-semibold uppercase tracking-[0.3em] text-primary/70">
-                Étape {step.step}
+        <div className="grid w-full gap-4 sm:grid-cols-3">
+          {features.map((feature) => (
+            <Card key={feature.title} className="flex h-full flex-col items-start gap-4 text-left">
+              <span className="inline-flex h-14 w-14 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+                {feature.icon}
               </span>
               <div className="space-y-2">
-                <h3 className="text-xl font-semibold text-text">{step.title}</h3>
-                <p className="text-sm font-medium text-primary/80">{step.subtitle}</p>
-              </div>
-              <p className="text-sm text-slate-600">{step.description}</p>
-              <div className="mt-auto rounded-2xl bg-muted/80 px-4 py-3 text-xs font-medium text-slate-600">
-                Livrable : {step.deliverable}
+                <h3 className="text-lg font-semibold text-text">{feature.title}</h3>
+                <p className="text-sm text-slate-600">{feature.description}</p>
               </div>
             </Card>
           ))}
         </div>
-      </section>
-
-      <section id="preuves" className="container space-y-12">
-        <div className="flex flex-col gap-4 text-center">
-          <Badge className="self-center bg-primary/10 text-primary">Résultats</Badge>
-          <h2 className="text-3xl font-semibold text-text">Des résultats mesurables dès les premières semaines</h2>
-          <p className="mx-auto max-w-3xl text-base text-slate-600">
-            Nous combinons l'analyse data, l'intelligence marché et l'opérationnel pour accélérer durablement votre acquisition
-            et la fidélisation.
-          </p>
-        </div>
-        <div className="grid gap-6 md:grid-cols-3">
-          {insights.map((insight) => (
-            <InsightCard key={insight.eyebrow} {...insight} />
-          ))}
-        </div>
-      </section>
-
-      <section className="container">
-        <EnablementHighlight />
-      </section>
-
-      <section id="contact" className="container space-y-12">
-        <div className="flex flex-col gap-4 text-center">
-          <Badge className="self-center bg-primary/10 text-primary">Contact</Badge>
-          <h2 className="text-3xl font-semibold text-text">Parlons de votre prochaine étape</h2>
-          <p className="mx-auto max-w-3xl text-base text-slate-600">
-            Programmez un échange de 30 minutes avec un consultant senior pour identifier comment l'audit peut soutenir vos
-            objectifs de croissance.
-          </p>
-        </div>
-        <ContactPanel />
       </section>
     </div>
   );

--- a/frontend/components/ui/navbar.tsx
+++ b/frontend/components/ui/navbar.tsx
@@ -8,9 +8,8 @@ import { Button, buttonVariants } from "./button";
 import { cn } from "../../lib/utils";
 
 const navLinks = [
-  { href: "/#services", label: "Services" },
-  { href: "/#methodologie", label: "Méthodologie" },
-  { href: "/#preuves", label: "Preuves" },
+  { href: "/analyser", label: "Analyser" },
+  { href: "/historique", label: "Historique" },
   { href: "/tarifs", label: "Tarifs" },
 ];
 
@@ -49,95 +48,94 @@ export function Navbar() {
   const toggleMenu = () => setIsMenuOpen((prev) => !prev);
 
   return (
-    <header className="sticky top-0 z-40 border-b border-border/80 bg-white/80 backdrop-blur">
-      <div className="container flex h-20 items-center justify-between gap-4">
-        <div className="flex items-center gap-10">
-          <Link
-            href="/"
-            className="text-lg font-semibold text-text focus-visible:outline-none"
-            aria-label="PubLégalFR"
-          >
-            PubLégalFR
-          </Link>
-          <nav className="hidden items-center gap-8 text-sm font-medium text-slate-600 sm:flex">
-            {navLinks.map((link) => {
-              const isSamePageLink = link.href.includes("#");
-              const isActive = isSamePageLink ? pathname === "/" : pathname.startsWith(link.href);
+    <header className="border-b border-border/80 bg-white/90 backdrop-blur">
+      <div className="container flex h-20 items-center justify-between gap-6">
+        <Link
+          href="/"
+          className="flex items-center gap-3 text-lg font-semibold text-text focus-visible:outline-none"
+          aria-label="PubLegalFR"
+        >
+          <span className="grid h-10 w-10 place-items-center rounded-full bg-primary text-sm font-semibold text-primary-foreground shadow-[0_10px_20px_rgba(31,58,224,0.35)]">
+            PL
+          </span>
+          PubLegalFR
+        </Link>
 
-              return (
-                <Link
-                  key={link.href}
-                  href={link.href}
-                  className={cn(
-                    "transition-colors focus-visible:outline-none",
-                    isActive
-                      ? "text-primary underline decoration-2 underline-offset-8"
-                      : "hover:text-primary",
-                  )}
-                  aria-current={isActive ? "page" : undefined}
-                >
-                  {link.label}
-                </Link>
-              );
-            })}
-          </nav>
-        </div>
-        <div className="flex items-center gap-3">
+        <nav className="hidden items-center gap-8 text-sm font-medium text-slate-600 md:flex">
+          {navLinks.map((link) => {
+            const isActive = pathname === link.href;
+
+            return (
+              <Link
+                key={link.href}
+                href={link.href}
+                className={cn(
+                  "transition-colors focus-visible:outline-none",
+                  isActive ? "text-primary" : "hover:text-primary",
+                )}
+                aria-current={isActive ? "page" : undefined}
+              >
+                {link.label}
+              </Link>
+            );
+          })}
+        </nav>
+
+        <div className="hidden items-center gap-4 md:flex">
           <Link
-            href="/historique"
+            href="/connexion"
             className="text-sm font-medium text-slate-600 transition-colors focus-visible:outline-none hover:text-primary"
           >
-            Nos cas clients
+            Connexion
           </Link>
-          <Button href="/analyser" size="md" className="hidden sm:inline-flex">
-            Demander un audit
+          <Button href="/analyser" size="md">
+            Analyser maintenant
           </Button>
-          <Button href="/analyser" size="md" className="sm:hidden">
-            Audit express
-          </Button>
-          <button
-            type="button"
-            onClick={toggleMenu}
-            className="inline-flex h-10 w-10 items-center justify-center rounded-lg text-slate-700 transition hover:bg-muted focus-visible:outline-none sm:hidden"
-            aria-label={isMenuOpen ? "Fermer le menu" : "Ouvrir le menu"}
-            aria-expanded={isMenuOpen}
-          >
-            {isMenuOpen ? (
-              <svg
-                className="h-5 w-5"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                aria-hidden="true"
-              >
-                <line x1="18" x2="6" y1="6" y2="18" />
-                <line x1="6" x2="18" y1="18" y2="6" />
-              </svg>
-            ) : (
-              <svg
-                className="h-5 w-5"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                aria-hidden="true"
-              >
-                <line x1="3" x2="21" y1="6" y2="6" />
-                <line x1="3" x2="21" y1="12" y2="12" />
-                <line x1="3" x2="21" y1="18" y2="18" />
-              </svg>
-            )}
-          </button>
         </div>
+
+        <button
+          type="button"
+          onClick={toggleMenu}
+          className="inline-flex h-10 w-10 items-center justify-center rounded-lg text-slate-700 transition hover:bg-muted focus-visible:outline-none md:hidden"
+          aria-label={isMenuOpen ? "Fermer le menu" : "Ouvrir le menu"}
+          aria-expanded={isMenuOpen}
+        >
+          {isMenuOpen ? (
+            <svg
+              className="h-5 w-5"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <line x1="18" x2="6" y1="6" y2="18" />
+              <line x1="6" x2="18" y1="18" y2="6" />
+            </svg>
+          ) : (
+            <svg
+              className="h-5 w-5"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <line x1="3" x2="21" y1="6" y2="6" />
+              <line x1="3" x2="21" y1="12" y2="12" />
+              <line x1="3" x2="21" y1="18" y2="18" />
+            </svg>
+          )}
+        </button>
       </div>
+
       {isMenuOpen && (
         <div
-          className="fixed inset-0 z-50 bg-slate-900/40 backdrop-blur-sm sm:hidden"
+          className="fixed inset-0 z-50 bg-slate-900/40 backdrop-blur-sm md:hidden"
           role="dialog"
           aria-modal="true"
           onClick={closeMenu}
@@ -149,7 +147,7 @@ export function Navbar() {
                   <Link
                     key={link.href}
                     href={link.href}
-                    className="rounded-xl bg-white/80 px-4 py-3 shadow-sm ring-1 ring-border/60 transition hover:bg-primary/10"
+                    className="rounded-2xl bg-white/80 px-4 py-3 shadow-sm ring-1 ring-border/60 transition hover:bg-primary/10"
                     onClick={closeMenu}
                   >
                     {link.label}
@@ -158,25 +156,18 @@ export function Navbar() {
               </nav>
               <div className="flex flex-col gap-3">
                 <Link
-                  href="/historique"
-                  className="rounded-xl bg-white/80 px-4 py-3 text-center text-base font-medium text-slate-600 shadow-sm ring-1 ring-border/60 transition hover:text-primary"
+                  href="/connexion"
+                  className="rounded-2xl bg-white/80 px-4 py-3 text-center text-base font-medium text-slate-600 shadow-sm ring-1 ring-border/60 transition hover:text-primary"
                   onClick={closeMenu}
                 >
-                  Nos cas clients
+                  Connexion
                 </Link>
                 <Link
                   href="/analyser"
                   className={buttonVariants({ className: "w-full" })}
                   onClick={closeMenu}
                 >
-                  Demander un audit
-                </Link>
-                <Link
-                  href="/analyser"
-                  className={buttonVariants({ className: "w-full", variant: "secondary" })}
-                  onClick={closeMenu}
-                >
-                  Audit express
+                  Analyser maintenant
                 </Link>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- align the hero section copy, badges, and calls-to-action with the provided compliance-focused layout
- replace the previous multi-section marketing content with focused feature cards for score global, export PDF, and historique
- update the navigation to match the reference links and actions, including the connexion link and primary CTA

## Testing
- npm run lint *(fails: Next.js attempted to install TypeScript via Yarn and hit a 403 while fetching @prisma/client)*

------
https://chatgpt.com/codex/tasks/task_e_68d6feb3930083299c0dd98199b94876